### PR TITLE
Feature/rails3 routes cleanup

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,4 @@
-Openproject::Application.routes.draw do
+OpenProject::Application.routes.draw do
 
   scope 'projects/:project_id' do
     resources :meetings, :only => [:new, :create, :index]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,5 @@
-#custom routes for this plugin
+Openproject::Application.routes.draw do
 
-OpenProject::Application.routes.prepend do
   scope 'projects/:project_id' do
     resources :meetings, :only => [:new, :create, :index]
   end
@@ -39,15 +38,5 @@ OpenProject::Application.routes.prepend do
                                         :via => :get,
                                         :as => 'tab'
     end
-  end
-
-  # TODO: check whether the rule for watching functionality in the core needs to be as restrictive
-  # as it currently is. If the core rule can be formulated more flexibly, this scope can be removed.
-  scope ':object_type/:object_id', :constraints => { :object_type => /meetings/,
-                                                     :object_id => /\d+/ } do
-    resources :watchers, :only => [:new]
-
-    match '/watch' => 'watchers#watch', :via => :post
-    match '/unwatch' => 'watchers#unwatch', :via => :delete
   end
 end

--- a/lib/openproject_meeting/engine.rb
+++ b/lib/openproject_meeting/engine.rb
@@ -8,18 +8,21 @@ module MeetingsPlugin
       Rails.application.config.assets.precompile += ["openproject_meeting.css"]
     end
 
-    config.to_prepare do
+    config.before_configuration do |app|
       # This is required for the routes to be loaded first
       # as the routes should be prepended so they take precedence over the core.
-      # This mechanism is a preliminary.
-      # The core should provide an api to do just that.
-      # Unfortunately this implementation here leads to duplicate entries when
-      # calling "rake routes". The tasks seems to load the routes twice. Based on the
-      # observations made prior to adding this statement, this seems to be limited to
-      # "rake routes". The reason for this assumption is that without the statement "rails s" would
-      # not load the routes but "rake routes" would.
-      require File.join(File.dirname(__FILE__), "/../../config/routes.rb")
+      app.config.paths['config/routes'].unshift File.join(File.dirname(__FILE__), "..", "..", "config", "routes.rb")
+    end
 
+    initializer "remove_duplicate_meeting_routes", :after => "add_routing_paths" do |app|
+      # removes duplicate entry from app.routes_reloader
+      # As we prepend the plugin's routes to the load_path up front and rails
+      # adds all engines' config/routes.rb later, we have double loaded the routes
+      # This is not harmful as such but leads to duplicate routes which decreases performance
+      app.routes_reloader.paths.uniq!
+    end
+
+    config.to_prepare do
       require 'redmine/plugin'
 
       require_dependency 'openproject_meeting/hooks'


### PR DESCRIPTION
adapts the plugin to the core's changed watch routes implementation. Doing so will no longer have the plugin overwriting the core's watch routes, e.g. on issues.
