### PR TITLE
Copied meetings now have the same start time as the original meeting

### DIFF
--- a/app/controllers/meetings_controller.rb
+++ b/app/controllers/meetings_controller.rb
@@ -64,7 +64,7 @@ class MeetingsController < ApplicationController
   def copy
     params[:copied_from_meeting_id] = @meeting.id
     params[:copied_meeting_agenda_text] = @meeting.agenda.text if @meeting.agenda.present?
-    @meeting = @meeting.copy(:author => User.current, :start_time => nil)
+    @meeting = @meeting.copy(:author => User.current)
     render :action => 'new', :project_id => @project
   end
 

--- a/features/meetings_copy.feature
+++ b/features/meetings_copy.feature
@@ -20,9 +20,10 @@ Feature: Copy meetings
           And there is a role "user"
           And the user "alice" is a "user" in the project "dingens"
           And there is 1 meeting in project "dingens" created by "alice" with:
-              | title    | Alices Meeting |
-              | location | CZI            |
-              | duration | 1.5            |
+              | title      | Alices Meeting      |
+              | location   | CZI                 |
+              | duration   | 1.5                 |
+              | start_time | 2013-03-27 18:55:00 |
 
   Scenario: Navigate to a meeting page with permission to create meetings
       Given the role "user" may have the following rights:
@@ -44,6 +45,9 @@ Feature: Copy meetings
        Then the "meeting[title]" field should contain "Alices Meeting"
         And the "meeting[location]" field should contain "CZI"
         And the "meeting[duration]" field should contain "1.5"
+        And the "meeting[start_date]" field should contain "2013-03-27"
+        And the "meeting[start_time(4i)]" field should contain "18"
+        And the "meeting[start_time(5i)]" field should contain "55"
        #And no participant should be selected as attendee
        #And only invited participants should be selected as invitees
 

--- a/spec/models/meeting_spec.rb
+++ b/spec/models/meeting_spec.rb
@@ -100,4 +100,37 @@ describe Meeting do
 
     it { meeting.watchers.collect(&:user).should =~ [user1, user2] }
   end
+
+  describe "Copied meetings" do
+    before do
+      project.add_member user1, [role]
+      project.add_member user2, [role]
+
+      project.save!
+
+      meeting.start_time = DateTime.new(2013,3,27,15,35)
+      meeting.participants.build(:user => user2)
+      meeting.save!
+    end
+
+    it "should have the same start_time as the original meeting" do
+      copy = meeting.copy({})
+      copy.start_time == meeting.start_time
+    end
+
+    it "should delete the copied meeting author if no author is given as parameter" do
+      copy = meeting.copy({})
+      copy.author.nil?
+    end
+
+    it "should set the author the provided author if one is given" do
+      copy = meeting.copy :author => user2
+      copy.author == user2
+    end
+
+    it "should clear participant ids and attended flags for all copied attendees" do
+      copy = meeting.copy({})
+      copy.participants.all { |p| p.id.nil? && !p.attended}
+    end
+  end
 end


### PR DESCRIPTION
Copied meetings now retain the original starttime value by preventing the controller
from setting the value to nil in the copy, which would automatically be filled by next day,
10:00 a.m. otherwise.
