### PR TITLE
Feature/rails3 fix copy agenda text

### DIFF
--- a/app/controllers/meeting_agendas_controller.rb
+++ b/app/controllers/meeting_agendas_controller.rb
@@ -4,7 +4,8 @@ class MeetingAgendasController < MeetingContentsController
   menu_item :meetings
 
   def close
-    @content.lock!
+    @meeting.close_agenda_and_copy_to_minutes!
+
     redirect_back_or_default :controller => 'meetings', :action => 'show', :id => @meeting
   end
 

--- a/app/controllers/meeting_agendas_controller.rb
+++ b/app/controllers/meeting_agendas_controller.rb
@@ -1,20 +1,20 @@
 class MeetingAgendasController < MeetingContentsController
   unloadable
-  
+
   menu_item :meetings
-  
+
   def close
     @content.lock!
     redirect_back_or_default :controller => 'meetings', :action => 'show', :id => @meeting
   end
-  
+
   def open
     @content.unlock!
     redirect_back_or_default :controller => 'meetings', :action => 'show', :id => @meeting
   end
-  
+
   private
-  
+
   def find_content
     @content = @meeting.agenda || @meeting.build_agenda
     @content_type = "meeting_agenda"

--- a/app/models/meeting.rb
+++ b/app/models/meeting.rb
@@ -112,6 +112,11 @@ class Meeting < ActiveRecord::Base
     copy
   end
 
+  def close_agenda_and_copy_to_minutes!
+    self.agenda.lock!
+    self.create_minutes(:text => agenda.text)
+  end
+
   protected
 
   def set_initial_values

--- a/app/models/meeting_minutes.rb
+++ b/app/models/meeting_minutes.rb
@@ -17,13 +17,6 @@ class MeetingMinutes < MeetingContent
 
   protected
 
-  def after_initialize
-    # set defaults
-    # avoid too deep stacks by not using the association helper methods
-    ag = MeetingAgenda.find_by_meeting_id(meeting_id)
-    self.text ||= ag.text if ag.present?
-  end
-
   MeetingMinutesJournal.class_eval do
     unloadable
 

--- a/features/meeting_close.feature
+++ b/features/meeting_close.feature
@@ -39,17 +39,21 @@ Feature: Close and open meeting agendas
         And I should see "Close the agenda to begin the Minutes" within ".meeting_minutes"
 
   @javascript
-  Scenario: Navigate to a meeting page with permission to close and close the meeting agenda
+  Scenario: Navigate to a meeting page with permission to close and close the meeting agenda copies the text and shows the meeting
       Given the role "user" may have the following rights:
             | view_meetings         |
             | close_meeting_agendas |
         And the meeting "Bobs Meeting" has 1 agenda with:
             | text | "blubber" |
        When I am already logged in as "alice"
-        And I go to the Meetings page for the project called "dingens"
-        And I click on "Bobs Meeting"
-        And I click on "Close"
-        And I click on "Agenda"
+        And I go to the show page of the meeting called "Bobs Meeting"
+        And I follow "Close"
+
+       Then I should be on the show page of the meeting called "Bobs Meeting"
+        And the minutes should contain the following text:
+            | blubber |
+
+       When I follow "Agenda"
        Then I should not see "Close" within ".meeting_agenda"
         And I should see "Open" within ".meeting_agenda"
 

--- a/features/step_definitions/meeting_steps.rb
+++ b/features/step_definitions/meeting_steps.rb
@@ -52,3 +52,7 @@ When /the agenda of the meeting "(.+)" changes meanwhile/ do |meeting|
   m.agenda.text = "oder oder?"
   m.agenda.save!
 end
+
+Then /^the minutes should contain the following text:$/ do |table|
+  step %Q{I should see "#{table.raw.first.first}" within "#meeting_minutes-text"}
+end

--- a/spec/models/meeting_spec.rb
+++ b/spec/models/meeting_spec.rb
@@ -11,6 +11,11 @@ describe Meeting do
   let(:user1) { FactoryGirl.create(:user) }
   let(:user2) { FactoryGirl.create(:user) }
   let(:meeting) { FactoryGirl.create(:meeting, :project => project, :author => user1) }
+  let(:agenda) do
+    meeting.create_agenda :text => "Meeting Agenda text"
+    meeting.agenda(true) # avoiding stale object errors
+  end
+
   let(:role) { FactoryGirl.create(:role, :permissions => [:view_meetings]) }
 
   before(:all) do
@@ -99,5 +104,21 @@ describe Meeting do
     end
 
     it { meeting.watchers.collect(&:user).should =~ [user1, user2] }
+  end
+
+  describe :close_agenda_and_copy_to_minutes do
+    before do
+      agenda #creating it
+
+      meeting.close_agenda_and_copy_to_minutes!
+    end
+
+    it "should create a meeting with the agenda's text" do
+      meeting.minutes.text.should == meeting.agenda.text
+    end
+
+    it "should close the agenda" do
+      meeting.agenda.locked?.should be_true
+    end
   end
 end


### PR DESCRIPTION
fixes copying of agenda text to the meeting's minutes upon closing the agenda
