### PR TITLE
Fixed bug on meeting creation showing the wrong time

### DIFF
--- a/app/assets/stylesheets/openproject_meeting.css
+++ b/app/assets/stylesheets/openproject_meeting.css
@@ -28,3 +28,12 @@ dt.meeting-minutes {
 div#activity dl.meetings dt span {
   padding-left: 15px;
 }
+
+div.flash.notice a.link_to_profile {
+  cursor:pointer;
+  color: #008BD0;
+}
+
+div.flash.notice a.link_to_profile:hover {
+  text-decoration: underline;
+}

--- a/app/controllers/meetings_controller.rb
+++ b/app/controllers/meetings_controller.rb
@@ -51,7 +51,13 @@ class MeetingsController < ApplicationController
       @meeting.agenda.author = User.current
     end
     if @meeting.save
-      flash[:notice] = l(:notice_successful_create)
+      text = l(:notice_successful_create)
+      link = l(:notice_timezone_missing)
+      if User.current.pref.time_zone == ""
+        text += " #{view_context.link_to(link, {:controller => :my, :action => :account},:class => "link_to_profile")}"
+      end
+      flash[:notice] = text.html_safe
+
       redirect_to :action => 'show', :id => @meeting
     else
       render :action => 'new', :project_id => @project

--- a/app/controllers/meetings_controller.rb
+++ b/app/controllers/meetings_controller.rb
@@ -107,7 +107,10 @@ class MeetingsController < ApplicationController
   def convert_params
     start_date, start_time_4i, start_time_5i = params[:meeting].delete(:start_date), params[:meeting].delete(:"start_time(4i)").to_i, params[:meeting].delete(:"start_time(5i)").to_i
     begin
-      params[:meeting][:start_time] = Date.parse(start_date) + start_time_4i.hours + start_time_5i.minutes
+      zone = (User.current.time_zone.nil?) ? Time.now.localtime : User.current.time_zone
+      time = Date.parse(start_date) + start_time_4i.hours + start_time_5i.minutes
+      time = time - zone.utc_offset
+      params[:meeting][:start_time] = time
     rescue ArgumentError
       params[:meeting][:start_time] = nil
     end

--- a/app/controllers/meetings_controller.rb
+++ b/app/controllers/meetings_controller.rb
@@ -111,11 +111,18 @@ class MeetingsController < ApplicationController
   end
 
   def convert_params
-    start_date, start_time_4i, start_time_5i = params[:meeting].delete(:start_date), params[:meeting].delete(:"start_time(4i)").to_i, params[:meeting].delete(:"start_time(5i)").to_i
+    start_date = params[:meeting].delete(:start_date)
+    start_time_4i = params[:meeting].delete(:"start_time(4i)")
+    start_time_5i = params[:meeting].delete(:"start_time(5i)")
     begin
-      zone = (User.current.time_zone.nil?) ? Time.now.localtime : User.current.time_zone
-      time = Date.parse(start_date) + start_time_4i.hours + start_time_5i.minutes
-      time = time - zone.utc_offset
+      timestring = start_date + " " + start_time_4i + ":" + start_time_5i; # + " " + zone;
+      if(User.current.time_zone.nil?)
+        time = Time.parse(timestring) #using the system time zone
+      else
+        Time.use_zone(User.current.time_zone) do
+          time = Time.zone.parse(timestring) #using the user-set time zone
+        end
+      end
       params[:meeting][:start_time] = time
     rescue ArgumentError
       params[:meeting][:start_time] = nil

--- a/app/controllers/meetings_controller.rb
+++ b/app/controllers/meetings_controller.rb
@@ -52,8 +52,8 @@ class MeetingsController < ApplicationController
     end
     if @meeting.save
       text = l(:notice_successful_create)
-      link = l(:notice_timezone_missing)
-      if User.current.pref.time_zone == ""
+      if User.current.time_zone.nil?
+        link = l(:notice_timezone_missing, :zone => Time.now.zone)
         text += " #{view_context.link_to(link, {:controller => :my, :action => :account},:class => "link_to_profile")}"
       end
       flash[:notice] = text.html_safe

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -35,3 +35,4 @@ de:
   notice_successful_notification: "Benachrichtigung erfolgreich gesendet"
   description_invite: eingeladen
   description_attended: teilgenommen
+  notice_timezone_missing: Keine Zeitzone eingestellt und daher UTC angenommen. Um Ihre Zeitzone einzustellen, clicken Sie bitte hier.

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -35,4 +35,4 @@ de:
   notice_successful_notification: "Benachrichtigung erfolgreich gesendet"
   description_invite: eingeladen
   description_attended: teilgenommen
-  notice_timezone_missing: Keine Zeitzone eingestellt und daher UTC angenommen. Um Ihre Zeitzone einzustellen, clicken Sie bitte hier.
+  notice_timezone_missing: Keine Zeitzone eingestellt und daher %{zone} angenommen. Um Ihre Zeitzone einzustellen, clicken Sie bitte hier.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -35,3 +35,4 @@ en:
   notice_successful_notification: "Notification sent successfully"
   description_invite: invited
   description_attended: attended
+  notice_timezone_missing: No time zone is set and UTC is assumed. To choose your time zone, please click here.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -35,4 +35,4 @@ en:
   notice_successful_notification: "Notification sent successfully"
   description_invite: invited
   description_attended: attended
-  notice_timezone_missing: No time zone is set and UTC is assumed. To choose your time zone, please click here.
+  notice_timezone_missing: No time zone is set and %{zone} is assumed. To choose your time zone, please click here.

--- a/features/meetings_new.feature
+++ b/features/meetings_new.feature
@@ -39,13 +39,13 @@ Feature: Create new meetings
             # TODO Gibt's eine bessere Möglichkeit validation errors abzufragen?
        Then I should see "Title can't be blank"
 
-  Scenario: Create a new meeting with a title and a date, time, and duration with no user time zone set
+  Scenario Outline: Create a new meeting with a title and a date, time, and duration with no and different time zones set
       Given the role "user" may have the following rights:
             | view_meetings   |
             | create_meetings |
        When I am already logged in as "alice"
        And the user "alice" has the following preferences
-              | time_zone | nil |
+              | time_zone | <t_zone> |
         And I go to the Meetings page for the project called "dingens"
         And I click on "New Meeting"
         And I fill in the following:
@@ -59,65 +59,12 @@ Feature: Create new meetings
         And I should see "FSR Sitzung 123"
         And I should see "03/28/2013 01:30 pm - 03:00 pm"
 
-  Scenario: Create a new meeting with a title and a date, time, and duration with UTC time zone set
-      Given the role "user" may have the following rights:
-            | view_meetings   |
-            | create_meetings |
-       When I am already logged in as "alice"
-       And the user "alice" has the following preferences
-              | time_zone | UTC |
-        And I go to the Meetings page for the project called "dingens"
-        And I click on "New Meeting"
-        And I fill in the following:
-            | meeting_title         | FSR Sitzung 123 |
-            | meeting_start_date    | 2013-03-28      |
-            | meeting_duration      | 1.5             |
-        And I select "13" from "meeting_start_time_4i"
-        And I select "30" from "meeting_start_time_5i"
-        And I click on "Create"
-       Then I should see "Successful creation."
-        And I should see "FSR Sitzung 123"
-        And I should see "03/28/2013 01:30 pm - 03:00 pm"
-
-  Scenario: Create a new meeting with a title and a date, time, and duration with CET time zone set
-      Given the role "user" may have the following rights:
-            | view_meetings   |
-            | create_meetings |
-       When I am already logged in as "alice"
-       And the user "alice" has the following preferences
-              | time_zone | CET |
-        And I go to the Meetings page for the project called "dingens"
-        And I click on "New Meeting"
-        And I fill in the following:
-            | meeting_title         | FSR Sitzung 123 |
-            | meeting_start_date    | 2013-03-28      |
-            | meeting_duration      | 1.5             |
-        And I select "13" from "meeting_start_time_4i"
-        And I select "30" from "meeting_start_time_5i"
-        And I click on "Create"
-       Then I should see "Successful creation."
-        And I should see "FSR Sitzung 123"
-        And I should see "03/28/2013 01:30 pm - 03:00 pm"
-
-  Scenario: Create a new meeting with a title and a date, time, and duration with CEST time zone set
-      Given the role "user" may have the following rights:
-            | view_meetings   |
-            | create_meetings |
-       When I am already logged in as "alice"
-       And the user "alice" has the following preferences
-              | time_zone | CEST |
-        And I go to the Meetings page for the project called "dingens"
-        And I click on "New Meeting"
-        And I fill in the following:
-            | meeting_title         | FSR Sitzung 123 |
-            | meeting_start_date    | 2013-03-28      |
-            | meeting_duration      | 1.5             |
-        And I select "13" from "meeting_start_time_4i"
-        And I select "30" from "meeting_start_time_5i"
-        And I click on "Create"
-       Then I should see "Successful creation."
-        And I should see "FSR Sitzung 123"
-        And I should see "03/28/2013 01:30 pm - 03:00 pm"
+  Examples:
+    | t_zone |
+    | nil    |
+    | UTC    |
+    | CET    |
+    | CEST   |
 
   @javascript
   Scenario: The start-time should be selectable in 5-minute increments

--- a/features/meetings_new.feature
+++ b/features/meetings_new.feature
@@ -39,7 +39,7 @@ Feature: Create new meetings
             # TODO Gibt's eine bessere Möglichkeit validation errors abzufragen?
        Then I should see "Title can't be blank"
 
-  Scenario: Create a new meeting with a title
+  Scenario: Create a new meeting with a title and a date, time, and duration
       Given the role "user" may have the following rights:
             | view_meetings   |
             | create_meetings |
@@ -47,11 +47,15 @@ Feature: Create new meetings
         And I go to the Meetings page for the project called "dingens"
         And I click on "New Meeting"
         And I fill in the following:
-            | meeting_title | FSR Sitzung 123 |
+            | meeting_title         | FSR Sitzung 123 |
+            | meeting_start_date    | 2013-03-28      |
+            | meeting_duration      | 1.5             |
+        And I select "13" from "meeting_start_time_4i"
+        And I select "30" from "meeting_start_time_5i"
         And I click on "Create"
        Then I should see "Successful creation."
         And I should see "FSR Sitzung 123"
-            # TODO sollten hier noch die "Defaults" abgefragt werden? Wahrscheinlich eher eine RSpec Sache?
+        And I should see "03/28/2013 01:30 pm - 03:00 pm"
 
   @javascript
   Scenario: The start-time should be selectable in 5-minute increments

--- a/features/meetings_new.feature
+++ b/features/meetings_new.feature
@@ -39,11 +39,73 @@ Feature: Create new meetings
             # TODO Gibt's eine bessere Möglichkeit validation errors abzufragen?
        Then I should see "Title can't be blank"
 
-  Scenario: Create a new meeting with a title and a date, time, and duration
+  Scenario: Create a new meeting with a title and a date, time, and duration with no user time zone set
       Given the role "user" may have the following rights:
             | view_meetings   |
             | create_meetings |
        When I am already logged in as "alice"
+       And the user "alice" has the following preferences
+              | time_zone | nil |
+        And I go to the Meetings page for the project called "dingens"
+        And I click on "New Meeting"
+        And I fill in the following:
+            | meeting_title         | FSR Sitzung 123 |
+            | meeting_start_date    | 2013-03-28      |
+            | meeting_duration      | 1.5             |
+        And I select "13" from "meeting_start_time_4i"
+        And I select "30" from "meeting_start_time_5i"
+        And I click on "Create"
+       Then I should see "Successful creation."
+        And I should see "FSR Sitzung 123"
+        And I should see "03/28/2013 01:30 pm - 03:00 pm"
+
+  Scenario: Create a new meeting with a title and a date, time, and duration with UTC time zone set
+      Given the role "user" may have the following rights:
+            | view_meetings   |
+            | create_meetings |
+       When I am already logged in as "alice"
+       And the user "alice" has the following preferences
+              | time_zone | UTC |
+        And I go to the Meetings page for the project called "dingens"
+        And I click on "New Meeting"
+        And I fill in the following:
+            | meeting_title         | FSR Sitzung 123 |
+            | meeting_start_date    | 2013-03-28      |
+            | meeting_duration      | 1.5             |
+        And I select "13" from "meeting_start_time_4i"
+        And I select "30" from "meeting_start_time_5i"
+        And I click on "Create"
+       Then I should see "Successful creation."
+        And I should see "FSR Sitzung 123"
+        And I should see "03/28/2013 01:30 pm - 03:00 pm"
+
+  Scenario: Create a new meeting with a title and a date, time, and duration with CET time zone set
+      Given the role "user" may have the following rights:
+            | view_meetings   |
+            | create_meetings |
+       When I am already logged in as "alice"
+       And the user "alice" has the following preferences
+              | time_zone | CET |
+        And I go to the Meetings page for the project called "dingens"
+        And I click on "New Meeting"
+        And I fill in the following:
+            | meeting_title         | FSR Sitzung 123 |
+            | meeting_start_date    | 2013-03-28      |
+            | meeting_duration      | 1.5             |
+        And I select "13" from "meeting_start_time_4i"
+        And I select "30" from "meeting_start_time_5i"
+        And I click on "Create"
+       Then I should see "Successful creation."
+        And I should see "FSR Sitzung 123"
+        And I should see "03/28/2013 01:30 pm - 03:00 pm"
+
+  Scenario: Create a new meeting with a title and a date, time, and duration with CEST time zone set
+      Given the role "user" may have the following rights:
+            | view_meetings   |
+            | create_meetings |
+       When I am already logged in as "alice"
+       And the user "alice" has the following preferences
+              | time_zone | CEST |
         And I go to the Meetings page for the project called "dingens"
         And I click on "New Meeting"
         And I fill in the following:


### PR DESCRIPTION
For some reason, identical code in the old Version creates DateTime objects with the local server time zone
while it always creates DateTime objects with UTC time zone in the rails3 branch. Therefore, the correct user time was only shown in the old Version, if user time zone and server time zone where identical.

Now the user preferences time zone is used to convert the time given by the user to UTC and store it. It will automatically be shown correctly to the user as before. If the user does not have a preferred time zone, the local time of the server will be used.
