### PR TITLE
enable plugin to be testable from OpenProject core

### DIFF
--- a/lib/openproject_meeting/engine.rb
+++ b/lib/openproject_meeting/engine.rb
@@ -4,8 +4,12 @@ module MeetingsPlugin
   class Engine < ::Rails::Engine
     isolate_namespace MeetingsPlugin
 
-    initializer 'openproject_meeting.precompile_assets' do
-      Rails.application.config.assets.precompile += ["openproject_meeting.css"]
+    initializer 'openproject_meeting.precompile_assets' do |app|
+      app.config.assets.precompile += ["openproject_meeting.css"]
+    end
+
+    initializer 'openproject_meeting.register_path_to_rspec' do |app|
+      app.config.plugins_to_test_paths << self.root
     end
 
     config.before_configuration do |app|

--- a/spec/controllers/meetings_controller_spec.rb
+++ b/spec/controllers/meetings_controller_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require File.dirname(__FILE__) + '/../spec_helper'
 
 describe MeetingsController do
   before(:each) do

--- a/spec/mailers/meeting_mailer_spec.rb
+++ b/spec/mailers/meeting_mailer_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require File.dirname(__FILE__) + '/../spec_helper'
 include Redmine::I18n
 
 describe MeetingMailer do

--- a/spec/models/meeting_agenda_journal_spec.rb
+++ b/spec/models/meeting_agenda_journal_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require File.dirname(__FILE__) + '/../spec_helper'
 require 'meeting_minutes'
 
 describe MeetingAgendaJournal do

--- a/spec/models/meeting_agenda_spec.rb
+++ b/spec/models/meeting_agenda_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require File.dirname(__FILE__) + '/../spec_helper'
 
 describe "MeetingAgenda" do
   before(:each) do

--- a/spec/models/meeting_minutes_journal_spec.rb
+++ b/spec/models/meeting_minutes_journal_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require File.dirname(__FILE__) + '/../spec_helper'
 require 'meeting_minutes'
 
 describe MeetingMinutesJournal do

--- a/spec/models/meeting_minutes_spec.rb
+++ b/spec/models/meeting_minutes_spec.rb
@@ -1,7 +1,7 @@
-require 'spec_helper'
+require File.dirname(__FILE__) + '/../spec_helper'
 
 describe "MeetingMinutes" do
-  before(:all) do
+  before do
     @min = FactoryGirl.build :meeting_minutes
   end
 

--- a/spec/models/meeting_spec.rb
+++ b/spec/models/meeting_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require File.dirname(__FILE__) + '/../spec_helper'
 
 describe Meeting do
   it {should belong_to :project}
@@ -18,7 +18,7 @@ describe Meeting do
 
   let(:role) { FactoryGirl.create(:role, :permissions => [:view_meetings]) }
 
-  before(:all) do
+  before do
     @m = FactoryGirl.build :meeting, :title => "dingens"
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,80 +1,11 @@
-# --- Instructions ---
-# Sort the contents of this file into a Spork.prefork and a Spork.each_run
-# block.
-#
-# The Spork.prefork block is run only once when the spork server is started.
-# You typically want to place most of your (slow) initializer code in here, in
-# particular, require'ing any 3rd-party gems that you don't normally modify
-# during development.
-#
-# The Spork.each_run block is run each time you run your specs.  In case you
-# need to load files that tend to change during development, require them here.
-# With Rails, your application modules are loaded automatically, so sometimes
-# this block can remain empty.
-#
-# Note: You can modify files loaded *from* the Spork.each_run block without
-# restarting the spork server.  However, this file itself will not be reloaded,
-# so if you change any of the code inside the each_run block, you still need to
-# restart the server.  In general, if you have non-trivial code in this file,
-# it's advisable to move it into a separate file so you can easily edit it
-# without restarting spork.  (For example, with RSpec, you could move
-# non-trivial code into a file spec/support/my_helper.rb, making sure that the
-# spec/support/* files are require'd from inside the each_run block.)
-#
-# Any code that is left outside the two blocks will be run during preforking
-# *and* during each_run -- that's probably not what you want.
-#
-# These instructions should self-destruct in 10 seconds.  If they don't, feel
-# free to delete them.
+# -- load spec_helper from OpenProject core
+require "spec_helper"
+require File.dirname(__FILE__) + '/support/plugin_spec_helper'
 
-require 'rubygems'
-
-# -- load the host app environment
-
-ENV["RAILS_ENV"] ||= 'test'
-require File.expand_path("#{ENV['RAILS_ROOT']}/config/environment.rb",  __FILE__)
-require 'rspec/rails'
-
-require 'rspec/autorun'
-require 'capybara/rails'
-
-Dir[Rails.root.join("spec/support/**/*.rb")].each {|f| require f}
-
-# -- load the gem dependencies
-
-require 'support/plugin_spec_helper'
-
-# preload agenda and minutes in order to have journal classes during tests
-require 'meeting_agenda'
-require 'meeting_minutes'
 # TODO require this stuff
-require 'factories/meeting_agenda_factory'
-require 'factories/meeting_agenda_journal_factory'
-require 'factories/meeting_factory'
-require 'factories/meeting_minutes_factory'
-require 'factories/meeting_minutes_journal_factory'
-require 'factories/meeting_participant_factory'
-
-RSpec.configure do |config|
-  config.mock_with :rspec
-
-  # If you're not using ActiveRecord, or you'd prefer not to run each of your
-  # examples within a transaction, remove the following line or assign false
-  # instead of true.
-  config.use_transactional_fixtures = true
-
-  # If true, the base class of anonymous controllers will be inferred
-  # automatically. This will be the default behavior in future versions of
-  # rspec-rails.
-  config.infer_base_class_for_anonymous_controllers = false
-
-  # Run specs in random order to surface order dependencies. If you find an
-  # order dependency and want to debug it, you can fix the order by providing
-  # the seed, which is printed after each run.
-  #     --seed 1234
-  config.order = "random"
-
-  config.treat_symbols_as_metadata_keys_with_true_values = true
-  config.run_all_when_everything_filtered = true
-end
-
+require File.dirname(__FILE__) + '/factories/meeting_agenda_factory'
+require File.dirname(__FILE__) + '/factories/meeting_agenda_journal_factory'
+require File.dirname(__FILE__) + '/factories/meeting_factory'
+require File.dirname(__FILE__) + '/factories/meeting_minutes_factory'
+require File.dirname(__FILE__) + '/factories/meeting_minutes_journal_factory'
+require File.dirname(__FILE__) + '/factories/meeting_participant_factory'


### PR DESCRIPTION
- added initializer to register plugin for tests out of the core
- changed spec helper that specs are working from core
- adapted specs
- changed wrong before(:all) to before in some specs
