### PR TITLE
Meets Bug #4040: Referencing work packages with ### in news, forums and meetings does not work

### DIFF
--- a/app/views/meeting_contents/_form.html.erb
+++ b/app/views/meeting_contents/_form.html.erb
@@ -21,7 +21,8 @@ See doc/COPYRIGHT.md for more details.
 <%= form_for content, :url => {:controller => '/' + content_type.pluralize, :action => 'update', :meeting_id => content.meeting}, :html => {:id => "#{content_type}_form", :method => :put} do |f| %>
 <%= error_messages_for content_type %>
 
-<p><%= f.text_area :text, :cols => 100, :rows => 25, :class => 'wiki-edit', :accesskey => accesskey(:edit) %></p>
+<p><%= f.text_area :text, :cols => 100, :rows => 25, :class => 'wiki-edit', :accesskey => accesskey(:edit),
+                   :'data-wp_autocomplete_url' => work_packages_auto_complete_path(:project_id => @project, :format => :json) %></p>
 <%= f.hidden_field :lock_version %>
 <p><label for="<%= content_type %>_comment"><%= Meeting.human_attribute_name(:comments) %></label><br /><%= f.text_field :comment, :size => 120 %></p>
 <p><%= submit_tag l(:button_save) %>

--- a/app/views/meeting_contents/_show.html.erb
+++ b/app/views/meeting_contents/_show.html.erb
@@ -36,7 +36,7 @@ See doc/COPYRIGHT.md for more details.
 
   <% if saved_meeting_content_text_present?(content) -%>
     <div id="<%= content_type %>-text" class="wiki show-<%= content_type %>">
-      <%= textilizable(content.text) %>
+      <%= textilizable(content.text, :object => @meeting) %>
     </div>
   <% else -%>
     <p id="<%= content_type %>-text" class="nodata show-<%= content_type %>"><%= l(:label_no_data) %></p>


### PR DESCRIPTION
```
* `#4040` Fix: Referencing work packages with ### in news, forums and meetings does not work
```
