### PR TITLE
Fix/15953 wiki mail translations

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -79,6 +79,6 @@ de:
   text_in_hours: "in Stunden"
   text_meeting_agenda_for_meeting: 'Agenda für die Besprechung "%{meeting}"'
   text_meeting_agenda_open_are_you_sure: "Nicht-gespeicherte Inhalte des Protokolls werden durch diese Aktion verworfen! Weitermachen?"
-  text_meeting_minutes_for_meeting: 'Protokoll für die Besprechungen "%{meeting}"'
+  text_meeting_minutes_for_meeting: 'Protokoll für die Besprechung "%{meeting}"'
   text_review_meeting_agenda: "%{author} hat die %{link} zur Einsicht freigegeben."
   text_review_meeting_minutes: "%{author} hat das %{link} zur Einsicht freigegeben."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -61,8 +61,8 @@ en:
   label_notify: "Send for review"
   label_version: "Version"
 
-  notice_timezone_missing: No time zone is set and %{zone} is assumed. To choose your time zone, please click here.
   notice_successful_notification: "Notification sent successfully"
+  notice_timezone_missing: No time zone is set and %{zone} is assumed. To choose your time zone, please click here.
 
   permission_create_meetings: "Create meetings"
   permission_edit_meetings: "Edit meetings"
@@ -76,9 +76,9 @@ en:
 
   project_module_meetings: "Meetings"
 
-  text_agenda_for_meeting: 'agenda for the meeting "%{meeting}"'
   text_in_hours: "in hours"
+  text_meeting_agenda_for_meeting: 'agenda for the meeting "%{meeting}"'
   text_meeting_agenda_open_are_you_sure: "Unsaved content in the minutes will be lost! Continue?"
-  text_minutes_for_meeting: 'minutes for the meeting "%{meeting}"'
+  text_meeting_minutes_for_meeting: 'minutes for the meeting "%{meeting}"'
   text_review_meeting_agenda: "%{author} has put the %{link} up for review."
   text_review_meeting_minutes: "%{author} has put the %{link} up for review."


### PR DESCRIPTION
When sending a meeting for review, german translations were used in the mail text.

This was due to generated i18n keys (which matched the german translations, but not the english translations).

This is fixed now. While I was at it, I also fixed a wrong german translation.

See: https://www.openproject.org/work_packages/15953
