### PR TITLE
Fix/delete meeting button

### DIFF
--- a/app/views/meetings/show.html.erb
+++ b/app/views/meetings/show.html.erb
@@ -44,7 +44,10 @@ See doc/COPYRIGHT.md for more details.
   <% end %>
   <% if authorize_for(:meetings, :destroy) %>
     <li class="toolbar-item">
-      <%= link_to({:controller => '/meetings', :action => 'destroy', :id => @meeting}, class: 'button') do %>
+      <%= link_to({controller: '/meetings', action: 'destroy', id: @meeting},
+                  class: 'button',
+                  method: :delete,
+                  confirm: l(:text_are_you_sure)) do %>
         <i class="button--icon icon-delete"></i> <%= l(:button_delete) %>
       <% end %>
     </li>

--- a/features/meetings_delete.feature
+++ b/features/meetings_delete.feature
@@ -73,17 +73,15 @@ Feature: Delete meetings
         And I click on "Bobs Meeting"
        Then I should see "Delete"
 
-  # TODO: kann nicht getestet werden bis die js confirm Geschichte geklärt ist
-  #@javascript
-  #Scenario: Delete an other-created meeting with permission to delete meetings
-  #    Given the role "user" may have the following rights:
-  #          | view_meetings   |
-  #          | delete_meetings |
-  #     When I am already logged in as "alice"
-  #      And I go to the Meetings page for the project called "dingens"
-  #      And I click on "Bobs Meeting"
-  #          # TODO Wie kriegt man das hin?
-  #          # Momentan bleibt das bei mir beim javascript "confirm" Dialog hängen
-  #      And I click on "Delete"
-  #     Then I should see "Meetings"
-  #      But I should not see "Bobs Meeting"
+  @javascript
+  Scenario: Delete a meeting with permission to delete meetings
+      Given the role "user" may have the following rights:
+            | view_meetings   |
+            | delete_meetings |
+       When I am already logged in as "alice"
+        And I go to the Meetings page for the project called "dingens"
+        And I click on "Bobs Meeting"
+        And I click on "Delete"
+        And I confirm the JS confirm dialog
+       Then I should see "Meetings"
+        But I should not see "Bobs Meeting"

--- a/features/meetings_delete.feature
+++ b/features/meetings_delete.feature
@@ -44,7 +44,6 @@ Feature: Delete meetings
               | duration   | 2:30                |
               | start_time | 2011-02-10 11:00:00 |
 
-  @javascript
   Scenario: Navigate to an other-created meeting with no permission to delete meetings
       Given the role "user" may have the following rights:
             | view_meetings |
@@ -53,7 +52,6 @@ Feature: Delete meetings
         And I click on "Bobs Meeting"
        Then I should not see "Delete"
 
-  @javascript
   Scenario: Navigate to a self-created meeting with permission to delete meetings
       Given the role "user" may have the following rights:
             | view_meetings   |
@@ -63,7 +61,6 @@ Feature: Delete meetings
         And I click on "Alices Meeting"
        Then I should see "Delete"
 
-  @javascript
   Scenario: Navigate to an other-created meeting with permission to delete meetings
       Given the role "user" may have the following rights:
             | view_meetings   |


### PR DESCRIPTION
Fixes meeting deletion broken in 54e65ac and activates the cuke that was deactivated from the beginning.

Additionally, it removes unnecessary usages of selenium. 

https://community.openproject.org/work_packages/20126
