### PR TITLE
Cleanup autocompletion

### DIFF
--- a/app/views/meeting_contents/_form.html.erb
+++ b/app/views/meeting_contents/_form.html.erb
@@ -22,8 +22,7 @@ See doc/COPYRIGHT.md for more details.
 <%= form_for content, :url => {:controller => '/' + content_type.pluralize, :action => 'update', :meeting_id => content.meeting}, :html => {:id => "#{content_type}_form", :method => :put} do |f| %>
 <%= error_messages_for content_type %>
 
-<p><%= f.text_area :text, :cols => 100, :rows => 25, :class => 'wiki-edit', :accesskey => accesskey(:edit),
-                   :'data-wp_autocomplete_url' => work_packages_auto_complete_path(:project_id => @project, :format => :json) %></p>
+<p><%= f.text_area :text, :cols => 100, :rows => 25, :class => 'wiki-edit', :accesskey => accesskey(:edit) %></p>
 <%= f.hidden_field :lock_version %>
 <p><label for="<%= content_type %>_comment"><%= Meeting.human_attribute_name(:comments) %></label><%= f.text_field :comment, :size => 120 %></p>
 <p><%= submit_tag l(:button_save), class: 'button -highlight' %>


### PR DESCRIPTION
## Description

This PR removes the `data-wp_autocomplete_url` attribute, whcih is possible as soon as https://github.com/opf/openproject/pull/3162 has been merged.
