### PR TITLE
Fix/reapply hotfix/rescue error on notify

### DIFF
--- a/app/controllers/meeting_contents_controller.rb
+++ b/app/controllers/meeting_contents_controller.rb
@@ -96,7 +96,7 @@ class MeetingContentsController < ApplicationController
       if recipients_with_errors == []
         flash[:notice] = l(:notice_successful_notification)
       else
-        flash[:notice] = l(:notice_notification_with_errors) + recipients_with_errors.join(", ")
+        flash[:error] = l(:error_notification_with_errors) + recipients_with_errors.join(", ")
       end
     end
     redirect_back_or_default controller: '/meetings', action: 'show', id: @meeting

--- a/app/controllers/meeting_contents_controller.rb
+++ b/app/controllers/meeting_contents_controller.rb
@@ -89,7 +89,7 @@ class MeetingContentsController < ApplicationController
       recipients_with_errors = []
       @content.meeting.participants.each do |recipient|
         begin
-          next if recipient.mail == author_mail and do_not_notify_author
+          next if recipient.mail == author_mail && do_not_notify_author
           MeetingMailer.content_for_review(@content, @content_type, recipient.mail).deliver
         rescue
           recipients_with_errors << recipient

--- a/app/controllers/meeting_contents_controller.rb
+++ b/app/controllers/meeting_contents_controller.rb
@@ -83,9 +83,10 @@ class MeetingContentsController < ApplicationController
 
   def notify
     unless @content.new_record?
-      recipients = @content.meeting.participants.collect(&:mail).reject { |r| r == @content.meeting.author.mail }
-      recipients << @content.meeting.author.mail unless @content.meeting.author.preference[:no_self_notified]
+      recipients = @content.meeting.participants.collect{ |p| p.mail }
+      recipients.reject!{ |r| r == @content.meeting.author.mail } if @content.meeting.author.preference[:no_self_notified]
       recipients_with_errors = []
+
       recipients.each do |recipient|
         begin
           MeetingMailer.content_for_review(@content, @content_type, recipient).deliver

--- a/app/controllers/meeting_contents_controller.rb
+++ b/app/controllers/meeting_contents_controller.rb
@@ -98,7 +98,8 @@ class MeetingContentsController < ApplicationController
       if recipients_with_errors == []
         flash[:notice] = l(:notice_successful_notification)
       else
-        flash[:error] = l(:error_notification_with_errors) + recipients_with_errors.map(&:name).join("; ")
+        flash[:error] = l(:error_notification_with_errors,
+                          recipients: recipients_with_errors.map(&:name).join('; '))
       end
     end
     redirect_back_or_default controller: '/meetings', action: 'show', id: @meeting

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -64,7 +64,6 @@ de:
   label_version: "Version"
 
   notice_successful_notification: "Benachrichtigung erfolgreich gesendet"
-  notice_notification_with_errors: "Benachrichtigung gesendet. Folgende Empfänger konnten nicht benachrichtigt werden: "
   notice_timezone_missing: Keine Zeitzone eingestellt und daher %{zone} angenommen. Um Ihre Zeitzone einzustellen, klicken Sie bitte hier.
 
   permission_create_meetings: "Besprechungen erstellen"

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -64,6 +64,7 @@ de:
   label_version: "Version"
 
   notice_successful_notification: "Benachrichtigung erfolgreich gesendet"
+  notice_notification_with_errors: "Benachrichtigung gesendet. Folgende Empfänger konnten nicht benachrichtigt werden: "
   notice_timezone_missing: Keine Zeitzone eingestellt und daher %{zone} angenommen. Um Ihre Zeitzone einzustellen, klicken Sie bitte hier.
 
   permission_create_meetings: "Besprechungen erstellen"

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -36,7 +36,7 @@ de:
   description_attended: "teilgenommen"
   description_invite: "eingeladen"
 
-  error_notification_with_errors: "Benachrichtigungversenden fehlgeschlagen. Folgende Empfänger konnten nicht benachrichtigt werden: "
+  error_notification_with_errors: "Benachrichtigungversenden fehlgeschlagen. Folgende Empfänger konnten nicht benachrichtigt werden: %{recipients}"
 
   events:
     meeting: Besprechung bearbeitet

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -64,7 +64,6 @@ en:
   label_version: "Version"
 
   notice_successful_notification: "Notification sent successfully"
-  notice_notification_with_errors: "Notification sent. The following recipients could not be notified: "
   notice_timezone_missing: No time zone is set and %{zone} is assumed. To choose your time zone, please click here.
 
   permission_create_meetings: "Create meetings"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,7 +44,7 @@ en:
     meeting_minutes: Meeting minutes edited
     meeting_minutes_created: Meeting minutes created
 
-  error_notification_with_errors: "Failed to send notification. The following recipients could not be notified: "
+  error_notification_with_errors: "Failed to send notification. The following recipients could not be notified: %{recipients}"
 
   label_meeting_hour: "Time (hour)"
   label_meeting_minute: "Time (minute)"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -64,6 +64,7 @@ en:
   label_version: "Version"
 
   notice_successful_notification: "Notification sent successfully"
+  notice_notification_with_errors: "Notification sent. The following recipients could not be notified: "
   notice_timezone_missing: No time zone is set and %{zone} is assumed. To choose your time zone, please click here.
 
   permission_create_meetings: "Create meetings"

--- a/spec/controllers/meeting_contents_controller_spec.rb
+++ b/spec/controllers/meeting_contents_controller_spec.rb
@@ -86,7 +86,7 @@ describe MeetingContentsController do
         it 'produces a flash message containing the mail addresses raising the error' do
           put 'notify', meeting_id: meeting.id
           meeting.participants.each do |participant|
-            expect(flash[:error]).to include(participant.mail)
+            expect(flash[:error]).to include(participant.name)
           end
         end
       end

--- a/spec/controllers/meeting_contents_controller_spec.rb
+++ b/spec/controllers/meeting_contents_controller_spec.rb
@@ -86,7 +86,7 @@ describe MeetingContentsController do
         it 'produces a flash message containing the mail addresses raising the error' do
           put 'notify', meeting_id: meeting.id
           meeting.participants.each do |participant|
-            expect(flash[:notice]).to include(participant.mail)
+            expect(flash[:error]).to include(participant.mail)
           end
         end
       end

--- a/spec/controllers/meeting_contents_controller_spec.rb
+++ b/spec/controllers/meeting_contents_controller_spec.rb
@@ -86,7 +86,7 @@ describe MeetingContentsController do
         it 'produces a flash message containing the mail addresses raising the error' do
           put 'notify', meeting_id: meeting.id
           meeting.participants.each do |participant|
-            expect(flash[:error]).to include(participant.name)
+            expect(flash[:notice]).to include(participant.mail)
           end
         end
       end


### PR DESCRIPTION
When merging release/4.0 into release/4.1 in 95b05e9, the changes made in `hotfix/rescue_error_on_notify` where lost. The spec however was ported over. This PR cherry-picks the former branch's commits to reapply the production code.

https://community.openproject.org/work_packages/20685
