### PR TITLE
Fix duplicate toolbar selector in cuke

### DIFF
--- a/app/views/meetings/show.html.erb
+++ b/app/views/meetings/show.html.erb
@@ -20,7 +20,8 @@ See doc/COPYRIGHT.md for more details.
 ++#%>
 
 <% html_title "#{l(:label_meeting)}: #{@meeting.title}" %>
-<%= toolbar title: "#{l(:label_meeting)}: #{link_to @meeting}" do %>
+<%= toolbar title: "#{l(:label_meeting)}: #{link_to @meeting}",
+            html: { class: 'meeting--main-toolbar' } do %>
   <% unless User.current.anonymous? %>
     <li class="toolbar-item">
       <div class="button">

--- a/features/meetings_copy.feature
+++ b/features/meetings_copy.feature
@@ -54,7 +54,7 @@ Feature: Copy meetings
        When I am already logged in as "alice"
         And I go to the Meetings page for the project called "dingens"
         And I click on "Alices Meeting"
-       Then I should see "Copy" within ".toolbar"
+       Then I should see "Copy" within ".meeting--main-toolbar"
 
   Scenario: Navigate to a meeting copy page
       Given the role "user" may have the following rights:


### PR DESCRIPTION
With https://github.com/finnlabs/openproject-meeting/commit/275a231cd12aaa01ce2b899d0388aadafd9a3692,
a new toolbar is added to a tab within `meetings#show`, causing the copy
feature to fail.

This fix simply uses a distinctive selector for the main toolbar.
