### PR TITLE
[22102] Apply new icon styling (Meeting)

### DIFF
--- a/app/helpers/meeting_contents_helper.rb
+++ b/app/helpers/meeting_contents_helper.rb
@@ -119,7 +119,7 @@ module MeetingContentsHelper
                             { controller: '/' + content_type.pluralize,
                               action: 'notify', meeting_id: meeting },
                             method: :put,
-                            class: 'button icon-context icon-mail'
+                            class: 'button icon-context icon-mail1'
     end
   end
 end

--- a/app/views/meeting_contents/_form.html.erb
+++ b/app/views/meeting_contents/_form.html.erb
@@ -26,7 +26,7 @@ See doc/COPYRIGHT.md for more details.
                    :'data-wp_autocomplete_url' => work_packages_auto_complete_path(:project_id => @project, :format => :json) %></p>
 <%= f.hidden_field :lock_version %>
 <p><label for="<%= content_type %>_comment"><%= Meeting.human_attribute_name(:comments) %></label><%= f.text_field :comment, :size => 120 %></p>
-<p><%= styled_button_tag l(:button_save), class: '-highlight -with-icon icon-yes' %>
+<p><%= styled_button_tag l(:button_save), class: '-highlight -with-icon icon-checkmark' %>
 <% path = send("preview_#{content_type}_path", content.meeting) %>
 <%= preview_link path, "#{content_type}_form", { class: 'button preview' } %>
 <%= link_to l(:button_cancel), "#",

--- a/app/views/meetings/edit.html.erb
+++ b/app/views/meetings/edit.html.erb
@@ -24,7 +24,7 @@ See doc/COPYRIGHT.md for more details.
 <%= toolbar title: "#{l(:label_meeting)} ##{@meeting.id}" %>
 <%= labelled_tabular_form_for @meeting, :url => {:controller => '/meetings', :action => 'update'}, :html => {:id => 'meeting-form', :method => :put} do |f| -%>
   <%= render :partial => 'form', :locals => {:f => f} %>
-<%= styled_button_tag l(:button_save), class: '-highlight -with-icon icon-yes' %>
+<%= styled_button_tag l(:button_save), class: '-highlight -with-icon icon-checkmark' %>
 <%= link_to l(:button_cancel), { :action => 'show', :id => @meeting },
       class: 'button' %>
 <% end if @project %>


### PR DESCRIPTION
This applies the new icon styling in the plugin. Note that this only works in combination with https://github.com/opf/openproject/pull/3873 since there the icon font is updated.

https://community.openproject.org/work_packages/22102/activity
