### PR TITLE
Remove unused icon definitions and update menu icon

### DIFF
--- a/app/assets/stylesheets/meeting/meeting.css.erb
+++ b/app/assets/stylesheets/meeting/meeting.css.erb
@@ -35,18 +35,6 @@ div.tabular > div { margin: 0;
 #meeting_agenda_preview fieldset {margin-top: 1em; background: url(<%= asset_path 'draft.png' %>);}
 #meeting_minutes_preview fieldset {margin-top: 1em; background: url(<%= asset_path 'draft.png' %>);}
 
-dt > .icon-meeting:before {
-  content: "\e057";
-}
-
-dt > .icon-meeting-agenda:before {
-  content: "\e023";
-}
-
-dt > .icon-meeting-minutes:before {
-  content: "\e022";
-}
-
 div.flash.notice a.link_to_profile {
   cursor:pointer;
   color: #008BD0;

--- a/lib/open_project/meeting/engine.rb
+++ b/lib/open_project/meeting/engine.rb
@@ -50,7 +50,7 @@ module OpenProject::Meeting
            caption: :project_module_meetings,
            param: :project_id,
            after: :wiki,
-           html: { class: 'icon2 icon-quote' }
+           html: { class: 'icon2 icon-meetings' }
 
       ActiveSupport::Inflector.inflections do |inflect|
         inflect.uncountable 'meeting_minutes'


### PR DESCRIPTION
This remove obsolete icon definitions. The classes are now defined in the core. This PR belongs to opf/openproject#3967 , where the icons are updated. For consistency the menu icon of meetings is changed too.
