### PR TITLE
[22397] Datepicker is missing when creating a meeting

### DIFF
--- a/app/views/meetings/_form.html.erb
+++ b/app/views/meetings/_form.html.erb
@@ -43,7 +43,7 @@ See doc/COPYRIGHT.md for more details.
             required: true,
             size:     10,
             no_label: true %>
-      <%= calendar_for('meeting_start_date') %>
+      <%= calendar_for('meeting-form-start-date') %>
       <label for="meeting-form-start-time" class="hidden-for-sighted">
         <%= Meeting.human_attribute_name(:start_time_hour) %>
         <%= l(:label_time_zone) %>


### PR DESCRIPTION
This corrects the id used for the datepicker.

https://community.openproject.org/work_packages/22397/activity
