### PR TITLE
Add iCalendar support

### DIFF
--- a/app/helpers/meeting_contents_helper.rb
+++ b/app/helpers/meeting_contents_helper.rb
@@ -37,6 +37,7 @@ module MeetingContentsHelper
     menu << meeting_content_edit_link(content_type) if can_edit_meeting_content?(content, content_type)
     menu << meeting_content_history_link(content_type, content.meeting)
     menu << meeting_content_notify_link(content_type, content.meeting) if saved_meeting_content_text_present?(content)
+    menu << meeting_content_icalendar_link(content_type, content.meeting) if saved_meeting_content_text_present?(content)
     menu.join(' ')
   end
 
@@ -120,6 +121,16 @@ module MeetingContentsHelper
                               action: 'notify', meeting_id: meeting },
                             method: :put,
                             class: 'button icon-context icon-mail1'
+    end
+  end
+  
+  def meeting_content_icalendar_link(content_type, meeting)
+    content_tag :li, '', class: 'toolbar-item' do
+      link_to_if_authorized l(:label_icalendar),
+                            { controller: '/' + content_type.pluralize,
+                              action: 'icalendar', meeting_id: meeting },
+                            method: :put,
+                            class: 'button icon-context icon-mail'
     end
   end
 end

--- a/app/mailers/meeting_mailer.rb
+++ b/app/mailers/meeting_mailer.rb
@@ -29,4 +29,43 @@ class MeetingMailer < UserMailer
     subject = "[#{@meeting.project.name}] #{I18n.t(:"label_#{content_type}")}: #{@meeting.title}"
     mail to: address, subject: subject
   end
+  
+  def publish_icalendar(content, content_type, address)
+    @meeting = content.meeting
+    @content_type = content_type
+    
+    open_project_headers 'Project' => @meeting.project.identifier,
+                         'Meeting-Id' => @meeting.id
+    headers['Content-Type'] = 'text/calendar; charset=utf-8; method="PUBLISH"; name="meeting.ics"'
+    headers['Content-Transfer-Encoding'] = '8bit'
+    subject = "[#{@meeting.project.name}] #{I18n.t(:"label_#{content_type}")}: #{@meeting.title}"
+    mystartdate = @meeting.start_time.strftime("%Y%m%dT%H%M%SZ")
+    myenddate = @meeting.end_time.strftime("%Y%m%dT%H%M%SZ")
+    url = meeting_url(@meeting)
+    now = DateTime.now.strftime("%Y%m%dT%H%M%SZ")
+
+    ical = "BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:OpenProject Meeting
+BEGIN:VEVENT
+SUMMARY:[#{@meeting.project.name}] #{@meeting.title}
+LOCATION:#{@meeting.location}
+DTSTAMP:#{now}
+DTSTART:#{mystartdate}
+DTEND:#{myenddate}
+DESCRIPTION:
+METHOD:PUBLISH
+ORGANIZER;CN=\"#{@meeting.author}\":MAILTO:#{@meeting.author.mail}
+UID:#{@meeting.id}@#{@meeting.project.identifier}
+SEQUENCE:0
+URL:#{url}
+END:VEVENT
+END:VCALENDAR"
+
+    mail(to: address, subject: subject) do |format|
+       format.ics {
+         render :text => ical, :layout => false
+      }
+    end
+  end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -58,6 +58,7 @@ en:
   label_meeting_date_time: "Date/Time"
   label_meeting_diff: "Diff"
   label_notify: "Send for review"
+  label_icalendar: "Send iCalendar"
   label_version: "Version"
   label_time_zone: "Time zone"
   label_start_date: "Start date"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,6 +33,7 @@ OpenProject::Application.routes.draw do
         put :close
         put :open
         put :notify
+        put :icalendar
         post :preview
       end
 

--- a/lib/open_project/meeting/default_data.rb
+++ b/lib/open_project/meeting/default_data.rb
@@ -25,6 +25,7 @@ module OpenProject
           :create_meeting_agendas,
           :close_meeting_agendas,
           :send_meeting_agendas_notification,
+          :send_meeting_agendas_icalendar,
           :create_meeting_minutes,
           :send_meeting_minutes_notification
         ]

--- a/lib/open_project/meeting/engine.rb
+++ b/lib/open_project/meeting/engine.rb
@@ -38,6 +38,7 @@ module OpenProject::Meeting
         permission :create_meeting_agendas, { meeting_agendas: [:update, :preview] }, require: :member
         permission :close_meeting_agendas, { meeting_agendas: [:close, :open] }, require: :member
         permission :send_meeting_agendas_notification, { meeting_agendas: [:notify] }, require: :member
+        permission :send_meeting_agendas_icalendar, { meeting_agendas: [:icalendar] }, require: :member
         permission :create_meeting_minutes, { meeting_minutes: [:update, :preview] }, require: :member
         permission :send_meeting_minutes_notification, { meeting_minutes: [:notify] }, require: :member
       end


### PR DESCRIPTION
Adds basic support for iCalendar notifications.
Closes #104 
### What it does:
- Adds a button to send iCalendar **notifications** (method PUBLISH) via email to all invited users
### What is not included:
- Locales other than English
- Tests
- Support for sending _updates_ / _cancel_ notifications
### What can / should be improved:
- Insert agenda items into description
- Use method=REQUEST instead of method=PUBLISH
- Any **substantial** modification (e.g. start/end time) should increment the sequence number of the calendar object
