### PR TITLE
[21850] Update Plugin styles for 'Nothing to display' (Meeting)

### DIFF
--- a/app/views/meeting_contents/_show.html.erb
+++ b/app/views/meeting_contents/_show.html.erb
@@ -41,7 +41,7 @@ See doc/COPYRIGHT.md for more details.
       <%= format_text(content.text, :object => @meeting) %>
     </div>
   <% else -%>
-    <p id="<%= content_type %>-text" class="nodata show-<%= content_type %>"><%= l(:label_no_data) %></p>
+    <%= no_results_box %>
   <% end -%>
 
   <%= javascript_tag(show_meeting_content_editor?(content, content_type) ? "$$('.show-#{content_type}').invoke('hide');" : "$$('.edit-#{content_type}').invoke('hide');") %>

--- a/app/views/meetings/index.html.erb
+++ b/app/views/meetings/index.html.erb
@@ -31,7 +31,7 @@ See doc/COPYRIGHT.md for more details.
 <% end %>
 
 <% if @meetings_by_start_year_month_date.empty? -%>
-<p class="nodata"><%= l(:label_no_data) %></p>
+  <%= no_results_box %>
 <% else -%>
 <div class="meetings meetings_by_month_year" id="activity">
 <% @meetings_by_start_year_month_date.each do |year,meetings_by_start_month_date| -%>


### PR DESCRIPTION
This uses the in opf/openproject#3665 defined new 'no results helper' in the meeting plugin.

https://community.openproject.org/work_packages/21850/activity
