### PR TITLE
[20446] [Accessibility] Some required fields are not properly labeled

### DIFF
--- a/app/views/meetings/_form.html.erb
+++ b/app/views/meetings/_form.html.erb
@@ -33,7 +33,9 @@ See doc/COPYRIGHT.md for more details.
 
   <div class="form--field">
     <label for="meeting-form-start-date" class="form--label -required">
-      <span aria-hidden="true"><%= Meeting.human_attribute_name(:start_date) %></span>
+      <span aria-hidden="true"><%= Meeting.human_attribute_name(:start_date) %>
+        <span class="form--label-required" aria-hidden="true">*</span>
+      </span>
       <span class="hidden-for-sighted"><%= l(:label_start_date)%></span>
     </label>
 
@@ -61,7 +63,9 @@ See doc/COPYRIGHT.md for more details.
 
   <div class="form--field">
     <label for="meeting-form-duration" class="form--label -required">
-      <%= Meeting.human_attribute_name(:duration) %>
+      <span aria-hidden="true"><%= Meeting.human_attribute_name(:duration) %>
+        <span class="form--label-required" aria-hidden="true">*</span>
+      </span>
       <span class="hidden-for-sighted"><%= l(:text_in_hours)%></span>
     </label>
 


### PR DESCRIPTION
This adds the required asterisk for some labels when creating a new Meeting-

https://community.openproject.org/work_packages/20446/activity
