### PR TITLE
[20428] [Accessibility] Some form fields are not pronounced with their entire label

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ version greater or equal to 3.0.0.
 Installation
 ------------
 
-Add the following line to the `Gemfile.plugins` to your OpenProject installation (if you use a different OpenProject version than OpenProject 4.1, adapt `:branch => "stable/4.1"` to your OpenProject version):
+Add the following line to the `Gemfile.plugins` to your OpenProject installation (if you use a different OpenProject version than OpenProject 5, adapt `:branch => "stable/5"` to your OpenProject version):
 
-`gem "openproject-meeting", :git => "https://github.com/finnlabs/openproject-meeting.git", :branch => "stable/4.1"`
+`gem "openproject-meeting", :git => "https://github.com/finnlabs/openproject-meeting.git", :branch => "stable/5"`
 
 Afterwards, run:
 
@@ -38,7 +38,7 @@ Deinstallation
 
 Remove the line
 
-`gem "openproject-meeting", :git => "https://github.com/finnlabs/openproject-meeting.git", :branch => "stable/4.1"`
+`gem "openproject-meeting", :git => "https://github.com/finnlabs/openproject-meeting.git", :branch => "stable/5"`
 
 from the file `Gemfile.plugins` and run:
 
@@ -72,7 +72,7 @@ Special thanks go to
 License
 -------
 
-(c) 2011 - 2014 - the OpenProject Foundation (OPF)
+(c) 2011 - 2015 - OpenProject Foundation (OPF)
 
 This plugin is licensed under the GNU GPL v3. See doc/COPYRIGHT.md and
 doc/GPL.txt for details.

--- a/app/views/meeting_contents/_show.html.erb
+++ b/app/views/meeting_contents/_show.html.erb
@@ -41,7 +41,7 @@ See doc/COPYRIGHT.md for more details.
       <%= format_text(content.text, :object => @meeting) %>
     </div>
   <% else -%>
-    <p id="<%= content_type %>-text" class="nodata show-<%= content_type %>"><%= l(:label_no_data) %></p>
+    <%= no_results_box %>
   <% end -%>
 
   <%= javascript_tag(show_meeting_content_editor?(content, content_type) ? "$$('.show-#{content_type}').invoke('hide');" : "$$('.edit-#{content_type}').invoke('hide');") %>

--- a/app/views/meetings/_form.html.erb
+++ b/app/views/meetings/_form.html.erb
@@ -34,7 +34,7 @@ See doc/COPYRIGHT.md for more details.
   <div class="form--field">
     <label for="meeting-form-start-date" class="form--label -required">
       <span aria-hidden="true"><%= Meeting.human_attribute_name(:start_date) %></span>
-      <span class="hidden-for-sighted"><%= l(:label_start_date)%></span>
+      <span class="hidden-for-sighted"><%= Meeting.human_attribute_name(:start_date) %></span>
     </label>
 
     <div class="form--field-container">
@@ -45,9 +45,11 @@ See doc/COPYRIGHT.md for more details.
             no_label: true %>
       <%= calendar_for('meeting-form-start-date') %>
       <label for="meeting-form-start-time" class="hidden-for-sighted">
-        <%= Meeting.human_attribute_name(:start_time_hour) %>
-        <%= l(:label_time_zone) %>
-        <%= Time.zone.to_s %>
+        <%= Meeting.human_attribute_name(:start_time) %>
+        <label lang="en">
+          <%= l(:label_time_zone) %>
+          <%= Time.zone.to_s %>
+        </label>
       </label>
       <%= f.text_field :start_time_hour,
             id: 'meeting-form-start-time',
@@ -61,8 +63,8 @@ See doc/COPYRIGHT.md for more details.
 
   <div class="form--field">
     <label for="meeting-form-duration" class="form--label -required">
-      <%= Meeting.human_attribute_name(:duration) %>
-      <span class="hidden-for-sighted"><%= l(:text_in_hours)%></span>
+      <span aria-hidden="true"><%= Meeting.human_attribute_name(:duration) %></span>
+      <span class="hidden-for-sighted"><%= Meeting.human_attribute_name(:duration) %></span>
     </label>
 
     <div class="form--field-container">

--- a/app/views/meetings/index.html.erb
+++ b/app/views/meetings/index.html.erb
@@ -31,7 +31,7 @@ See doc/COPYRIGHT.md for more details.
 <% end %>
 
 <% if @meetings_by_start_year_month_date.empty? -%>
-<p class="nodata"><%= l(:label_no_data) %></p>
+  <%= no_results_box %>
 <% else -%>
 <div class="meetings meetings_by_month_year" id="activity">
 <% @meetings_by_start_year_month_date.each do |year,meetings_by_start_month_date| -%>

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -1,0 +1,56 @@
+ar:
+  activerecord:
+    attributes:
+      meeting:
+        location: الموقع
+        duration: المدّة
+        participants: المشاركون
+        participants_attended: الحضور
+        participants_invited: المدعوّون
+        start_time: الوقت
+    models:
+      meeting_agenda: جدول الأعمال
+      meeting_minutes: محضر الجلسة
+  description_attended: حَضَر
+  description_invite: دعا
+  events:
+    meeting: تحرير الاجتماع
+    meeting_agenda: تحرير جدول أعمال الاجتماع
+    meeting_agenda_closed: أُغْلِق جدول أعمال الاجتماع
+    meeting_agenda_opened: فُتِح جدول أعمال الاجتماع
+    meeting_minutes: تحرير محضر الجلسة
+    meeting_minutes_created: إنشاء محضر الجلسة
+  error_notification_with_errors: 'فشِل في إرسال الإشعار. لم يتم إشعار المستلمين التالية أسماؤهم: %{recipients}'
+  label_meeting: الاجتماع
+  label_meeting_plural: الاجتماعات
+  label_meeting_new: اجتماع جديد
+  label_meeting_edit: تحرير الاجتماع
+  label_meeting_agenda: جدول الأعمال
+  label_meeting_minutes: محضر الجلسة
+  label_meeting_close: مُغلق
+  label_meeting_open: مفتوح
+  label_meeting_agenda_close: أغلِق جدول الأعمال للبدء في محضر الجلسة
+  label_meeting_date_time: التاريخ/الوقت
+  label_meeting_diff: الاختلاف
+  label_notify: إرسال للمراجعة
+  label_version: النسخة
+  label_time_zone: المنطقة الزمنية
+  label_start_date: تاريخ البدء
+  notice_successful_notification: تم إرسال الإشعار بنجاح
+  notice_timezone_missing: 'لم يتم تعيين المنطقة الزمنية و%{zone} مُفترض. لاختيار منطقتك الزمنية، من فضلك اضغط هنا.'
+  permission_create_meetings: إنشاء الاجتماعات
+  permission_edit_meetings: تحرير الاجتماعات
+  permission_delete_meetings: إلغاء الاجتماعات
+  permission_view_meetings: عرض الاجتماعات
+  permission_create_meeting_agendas: إدارة جداول الأعمال
+  permission_close_meeting_agendas: إغلاق جداول الأعمال
+  permission_send_meeting_agendas_notification: أرسِل إشعارًا لمراجعة جداول الأعمال
+  permission_create_meeting_minutes: إدارة محضر الجلسة
+  permission_send_meeting_minutes_notification: أرسِل إشعارًا لمراجعة محضر الجلسة
+  project_module_meetings: الاجتماعات
+  text_in_hours: في الساعات
+  text_meeting_agenda_for_meeting: 'جدول أعمال اجتماع "%{meeting}"'
+  text_meeting_agenda_open_are_you_sure: سيتم فقدان محتوى محضر الجلسة التي لم يتم حفظها! هل تريد المتابعة؟
+  text_meeting_minutes_for_meeting: 'محضر الجسلة لاجتماع "%{meeting}"'
+  text_review_meeting_agenda: '%{author} طرح %{link} للمراجعة.'
+  text_review_meeting_minutes: '%{author} طرح %{link} للمراجعة.'

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -34,6 +34,8 @@ da:
   label_meeting_diff: Uenigheder
   label_notify: Send til vurdering
   label_version: Version
+  label_time_zone: Time zone
+  label_start_date: Start date
   notice_successful_notification: Påmindelse er afsendt
   notice_timezone_missing: 'Der er ikke sat en tidszone og systemet har valgt %{zone}. For at vælge din egen tidszone, klik venligst her.'
   permission_create_meetings: Opret møder

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -34,6 +34,8 @@ de:
   label_meeting_diff: Differenz
   label_notify: Zur Einsicht verschicken
   label_version: Version
+  label_time_zone: Time zone
+  label_start_date: Start date
   notice_successful_notification: Benachrichtigung erfolgreich gesendet
   notice_timezone_missing: 'Keine Zeitzone eingestellt und daher %{zone} angenommen. Um Ihre Zeitzone einzustellen, klicken Sie bitte hier.'
   permission_create_meetings: Besprechungen erstellen

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -34,8 +34,8 @@ de:
   label_meeting_diff: Differenz
   label_notify: Zur Einsicht verschicken
   label_version: Version
-  label_time_zone: Time zone
-  label_start_date: Start date
+  label_time_zone: Zeitzone
+  label_start_date: Beginn
   notice_successful_notification: Benachrichtigung erfolgreich gesendet
   notice_timezone_missing: 'Keine Zeitzone eingestellt und daher %{zone} angenommen. Um Ihre Zeitzone einzustellen, klicken Sie bitte hier.'
   permission_create_meetings: Besprechungen erstellen

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -34,6 +34,8 @@ fr:
   label_meeting_diff: Différence
   label_notify: Envoyer pour révision
   label_version: Version
+  label_time_zone: Time zone
+  label_start_date: Start date
   notice_successful_notification: Notification envoyée avec succès
   notice_timezone_missing: "Aucun fuseau horaire n'est défini et %{zone} est supposé. Pour choisir votre fuseau horaire, veuillez cliquer ici."
   permission_create_meetings: Créer des réunions

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -34,8 +34,8 @@ fr:
   label_meeting_diff: Différence
   label_notify: Envoyer pour révision
   label_version: Version
-  label_time_zone: Time zone
-  label_start_date: Start date
+  label_time_zone: Fuseau horaire
+  label_start_date: Date de début
   notice_successful_notification: Notification envoyée avec succès
   notice_timezone_missing: "Aucun fuseau horaire n'est défini et %{zone} est supposé. Pour choisir votre fuseau horaire, veuillez cliquer ici."
   permission_create_meetings: Créer des réunions

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -34,6 +34,8 @@ he:
   label_meeting_diff: Diff
   label_notify: שלח לבדיקה
   label_version: גירסה
+  label_time_zone: Time zone
+  label_start_date: Start date
   notice_successful_notification: הודעה נשלחה בהצלחה
   notice_timezone_missing: 'אין איזור זמן מוגדר, ההערכה היא %{zone}. כדי לבחור את איזור הזמן שלך, אנא לחץ כאן.'
   permission_create_meetings: צור פגישות

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -1,0 +1,54 @@
+hr:
+  activerecord:
+    attributes:
+      meeting:
+        location: Lokacija
+        duration: Trajanje
+        participants: Učesnici
+        participants_attended: Sudionici
+        participants_invited: Pozvane osobe
+        start_time: Vrijeme
+    models:
+      meeting_agenda: Dnevni red
+      meeting_minutes: Minute
+  description_attended: prisustvovali su
+  description_invite: pozvani
+  events:
+    meeting: Sastanak uređen
+    meeting_agenda: Dnevni red sastanka uređen
+    meeting_agenda_closed: Dnevni red sastanka zaključen
+    meeting_agenda_opened: Dnevni red sastanka otvoren
+    meeting_minutes: Minute sastanka uređene
+    meeting_minutes_created: Minute sastanka dodane
+  error_notification_with_errors: 'Neuspjelo slanje notifikacije. Sljedeći korisnici nisu mogli biti obaviješteni: %{recipients}'
+  label_meeting: Sastanak
+  label_meeting_plural: Sastanci
+  label_meeting_new: Novi sastanak
+  label_meeting_edit: Uredite sastanak
+  label_meeting_agenda: Dnevni red
+  label_meeting_minutes: Minute
+  label_meeting_close: Zatvori
+  label_meeting_open: Otvori
+  label_meeting_agenda_close: Zatvorite dnevni red, da bi započeli s Minutama
+  label_meeting_date_time: Datum/vrijeme
+  label_meeting_diff: Razl
+  label_notify: Šalji na pregled
+  label_version: Verzija
+  notice_successful_notification: Notifikacija uspješno poslana
+  notice_timezone_missing: 'Vremenska zona nije postavljena na osnovu zamišljene %{zone} zone. Da bi ste odabrali vremensku zonu molim vas kliknite ovdje.'
+  permission_create_meetings: Dodaj sastanke
+  permission_edit_meetings: Uredi sastanke
+  permission_delete_meetings: Izbriši sastanke
+  permission_view_meetings: Pogledaj sastanke
+  permission_create_meeting_agendas: Upravljanje dnevnim redom
+  permission_close_meeting_agendas: Zaključi dnevni red
+  permission_send_meeting_agendas_notification: Pošalji notifikaciju o uređenim dnevnim redovima
+  permission_create_meeting_minutes: Upravljaj minutama
+  permission_send_meeting_minutes_notification: Pošalji notifikaciju o uređenim minutama
+  project_module_meetings: Sastanci
+  text_in_hours: u satima
+  text_meeting_agenda_for_meeting: 'dnevni red za sastank "%{meeting}"'
+  text_meeting_agenda_open_are_you_sure: Nepohranjeni sadržaj u minutama biti će izgubljen! Da li želite nastaviti?
+  text_meeting_minutes_for_meeting: 'minute za sastanak "%{meeting}"'
+  text_review_meeting_agenda: '%{author} je dodao poveznicu %{link} za provjeru.'
+  text_review_meeting_minutes: '%{author} je dodao poveznicu %{link} za provjeru.'

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -34,6 +34,8 @@ hr:
   label_meeting_diff: Razl
   label_notify: Šalji na pregled
   label_version: Verzija
+  label_time_zone: Time zone
+  label_start_date: Start date
   notice_successful_notification: Notifikacija uspješno poslana
   notice_timezone_missing: 'Vremenska zona nije postavljena na osnovu zamišljene %{zone} zone. Da bi ste odabrali vremensku zonu molim vas kliknite ovdje.'
   permission_create_meetings: Dodaj sastanke

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -34,6 +34,8 @@ it:
   label_meeting_diff: Differenza
   label_notify: Invia per revisione
   label_version: Versione
+  label_time_zone: Time zone
+  label_start_date: Start date
   notice_successful_notification: Notifica inviata con successo
   notice_timezone_missing: 'Nessun fuso orario è impostato e la %{zone} è un requisito necessario. Per scegliere il tuo fuso orario, fare clic qui.'
   permission_create_meetings: Creare riunioni

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -34,6 +34,8 @@ nl:
   label_meeting_diff: Diff
   label_notify: Verzenden voor revisie
   label_version: Versie
+  label_time_zone: Time zone
+  label_start_date: Start date
   notice_successful_notification: Notificatie succesvol verzonden
   notice_timezone_missing: 'Geen tijdzone is ingesteld en %{zone} is aangenomen. Om uw tijdzone te kiezen, klik dan hier.'
   permission_create_meetings: Creëer vergaderingen

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -34,6 +34,8 @@
   label_meeting_diff: Forskjell
   label_notify: Send till gjennomgang
   label_version: Versjon
+  label_time_zone: Time zone
+  label_start_date: Start date
   notice_successful_notification: Påminning sendt
   notice_timezone_missing: 'Ingen tidssone angis og %{zone} antas. Vennligst klikk her for å velge egen tidssone.'
   permission_create_meetings: Opprett møter

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -34,6 +34,8 @@ pl:
   label_meeting_diff: Różnice
   label_notify: Wyślij do przeglądu
   label_version: Wersja
+  label_time_zone: Time zone
+  label_start_date: Start date
   notice_successful_notification: Powiadomienia wysłane pomyślnie
   notice_timezone_missing: 'No time zone is set and %{zone} is assumed. To choose your time zone, please click here.'
   permission_create_meetings: Utwórz spotkanie

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -34,6 +34,8 @@ pt-BR:
   label_meeting_diff: Diferenças
   label_notify: Enviar para revisão
   label_version: Versão
+  label_time_zone: Time zone
+  label_start_date: Start date
   notice_successful_notification: Notificação enviada com sucesso
   notice_timezone_missing: 'Nenhum fuso horário está definido, portanto assumiu-se %{zone}. Para escolher o seu fuso horário, clique aqui.'
   permission_create_meetings: Criar reuniões

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -34,8 +34,8 @@ pt-BR:
   label_meeting_diff: Diferenças
   label_notify: Enviar para revisão
   label_version: Versão
-  label_time_zone: Time zone
-  label_start_date: Start date
+  label_time_zone: Fuso horário
+  label_start_date: Data de início
   notice_successful_notification: Notificação enviada com sucesso
   notice_timezone_missing: 'Nenhum fuso horário está definido, portanto assumiu-se %{zone}. Para escolher o seu fuso horário, clique aqui.'
   permission_create_meetings: Criar reuniões

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -34,8 +34,8 @@ ru:
   label_meeting_diff: Различия
   label_notify: Отправка на рецензию
   label_version: Версия
-  label_time_zone: Time zone
-  label_start_date: Start date
+  label_time_zone: Часовой пояс
+  label_start_date: Дата начала
   notice_successful_notification: Уведомление успешно отправленно
   notice_timezone_missing: 'Не установлен часовой пояс и применена %{zone}. Чтобы выбрать часовой пояс, пожалуйста, нажмите сюда.'
   permission_create_meetings: Создание совещания

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -34,6 +34,8 @@ ru:
   label_meeting_diff: Различия
   label_notify: Отправка на рецензию
   label_version: Версия
+  label_time_zone: Time zone
+  label_start_date: Start date
   notice_successful_notification: Уведомление успешно отправленно
   notice_timezone_missing: 'Не установлен часовой пояс и применена %{zone}. Чтобы выбрать часовой пояс, пожалуйста, нажмите сюда.'
   permission_create_meetings: Создание совещания

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -34,6 +34,8 @@ sk:
   label_meeting_diff: Rozdieľ
   label_notify: Odoslať na revíziu
   label_version: Verzia
+  label_time_zone: Time zone
+  label_start_date: Start date
   notice_successful_notification: Notifikácia úspešne odoslaná
   notice_timezone_missing: 'Časové pásmo nebolo špecificky nastavené, použilo sa teda %{zone}. Ak chcete vybrať iné časové pásmo, kliknite prosím tu.'
   permission_create_meetings: Vytvárať stretnutia

--- a/config/locales/sv-SE.yml
+++ b/config/locales/sv-SE.yml
@@ -34,6 +34,8 @@ sv:
   label_meeting_diff: Skillnad
   label_notify: Skicka för granskning
   label_version: Version
+  label_time_zone: Time zone
+  label_start_date: Start date
   notice_successful_notification: Underrättelse skickades
   notice_timezone_missing: 'Ingen tidszon angiven och %{zone} antas. För att välja din tidszon, vänligen klicka här.'
   permission_create_meetings: Skapa möten

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -1,0 +1,56 @@
+zh:
+  activerecord:
+    attributes:
+      meeting:
+        location: 地點
+        duration: 會議長度
+        participants: 參加人員
+        participants_attended: 出席人員
+        participants_invited: 受邀人員
+        start_time: 時間
+    models:
+      meeting_agenda: 會議大綱
+      meeting_minutes: 會議記錄
+  description_attended: 出席人員
+  description_invite: 已邀請
+  events:
+    meeting: 會議已編輯
+    meeting_agenda: 會議大綱已編輯
+    meeting_agenda_closed: 會議大綱已定案
+    meeting_agenda_opened: 會議大綱開啟
+    meeting_minutes: 會議記錄已編輯
+    meeting_minutes_created: 會議記錄已建立
+  error_notification_with_errors: '傳送通知失敗。以下的收件者將不會被通知到: %{recipients}'
+  label_meeting: 會議
+  label_meeting_plural: 會議
+  label_meeting_new: 新增會議
+  label_meeting_edit: 編輯會議
+  label_meeting_agenda: 會議大綱
+  label_meeting_minutes: 會議記錄
+  label_meeting_close: 結束
+  label_meeting_open: 開始
+  label_meeting_agenda_close: 定案會議大綱以便開始會議記錄
+  label_meeting_date_time: 日期 / 時間
+  label_meeting_diff: Diff
+  label_notify: 送出審閱
+  label_version: 版本
+  label_time_zone: 時區
+  label_start_date: 開始日期
+  notice_successful_notification: 通知傳送成功
+  notice_timezone_missing: '沒有設定時區，預設時區為 %{zone} 。請按這裡選擇您的時區。'
+  permission_create_meetings: 建立會議
+  permission_edit_meetings: 編輯會議
+  permission_delete_meetings: 刪除會議
+  permission_view_meetings: 檢視會議
+  permission_create_meeting_agendas: 管理會議
+  permission_close_meeting_agendas: 定案會議大綱
+  permission_send_meeting_agendas_notification: 傳送會議大綱審閱通知
+  permission_create_meeting_minutes: 管理會議記錄
+  permission_send_meeting_minutes_notification: 傳送會議記錄審閱通知
+  project_module_meetings: 會議
+  text_in_hours: 在一小時內
+  text_meeting_agenda_for_meeting: '%{meeting} 的會議大綱'
+  text_meeting_agenda_open_are_you_sure: 會議記錄中未儲存的內容會遺失！確定要繼續嗎？
+  text_meeting_minutes_for_meeting: '%{meeting} 的會議記錄'
+  text_review_meeting_agenda: '%{author} 已經放上 %{link} 來審閱'
+  text_review_meeting_minutes: '%{author} 已經放上 %{link} 來審閱'

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -31,7 +31,7 @@ zh:
   label_meeting_open: 開始
   label_meeting_agenda_close: 定案會議大綱以便開始會議記錄
   label_meeting_date_time: 日期 / 時間
-  label_meeting_diff: Diff
+  label_meeting_diff: 比較
   label_notify: 送出審閱
   label_version: 版本
   label_time_zone: 時區

--- a/lib/open_project/meeting/version.rb
+++ b/lib/open_project/meeting/version.rb
@@ -20,6 +20,6 @@
 
 module OpenProject
   module Meeting
-    VERSION = "5.0.0-alpha"
+    VERSION = "5.1.0"
   end
 end


### PR DESCRIPTION
This changes the used labels (if possible) for a correct translation. In two cases the `lang`-attribute was set since there is no translation at the moment.

https://community.openproject.org/work_packages/20428/activity
