### PR TITLE
[20499] [Accessibility] Some error messages cannot be perceived with the screen reader

### DIFF
--- a/app/views/meetings/_form.html.erb
+++ b/app/views/meetings/_form.html.erb
@@ -24,7 +24,7 @@ See doc/COPYRIGHT.md for more details.
 <section class="form--section">
 
   <div class="form--field">
-    <%= f.text_field :title, :required => true, :size => 60, :class => "autofocus" %>
+    <%= f.text_field :title, :required => true, :size => 60 %>
   </div>
 
   <div class="form--field">
@@ -62,7 +62,7 @@ See doc/COPYRIGHT.md for more details.
   <div class="form--field">
     <label for="meeting-form-duration" class="form--label -required">
       <%= Meeting.human_attribute_name(:duration) %>
-      <span class="hidden-for-sighted"><%= l(:text_in_hours)%></span>
+      <span class="hidden-for-sighted"><%= l(:text_in_hours)%>  <%=l(:text_hours_between, min: 1, max: 168) %></span>
     </label>
 
     <div class="form--field-container">


### PR DESCRIPTION
This makes changes on meeting form for better accessibility. In detail:
- The `autofocus` was removed to set the focus on the first error field.
- The label for 'duration' was changed to let the screenreader read the allowed range.

_Note_ This will only work with this core PR: https://github.com/opf/openproject/pull/4265

https://community.openproject.com/work_packages/20449/activity
