### PR TITLE
[20428] [Accessibility] Some form fields are not pronounced with their entire label

### DIFF
--- a/app/views/meetings/_form.html.erb
+++ b/app/views/meetings/_form.html.erb
@@ -34,7 +34,7 @@ See doc/COPYRIGHT.md for more details.
   <div class="form--field">
     <label for="meeting-form-start-date" class="form--label -required">
       <span aria-hidden="true"><%= Meeting.human_attribute_name(:start_date) %></span>
-      <span class="hidden-for-sighted"><%= l(:label_start_date)%></span>
+      <span class="hidden-for-sighted"><%= Meeting.human_attribute_name(:start_date) %></span>
     </label>
 
     <div class="form--field-container">
@@ -45,9 +45,11 @@ See doc/COPYRIGHT.md for more details.
             no_label: true %>
       <%= calendar_for('meeting-form-start-date') %>
       <label for="meeting-form-start-time" class="hidden-for-sighted">
-        <%= Meeting.human_attribute_name(:start_time_hour) %>
-        <%= l(:label_time_zone) %>
-        <%= Time.zone.to_s %>
+        <%= Meeting.human_attribute_name(:start_time) %>
+        <label lang="en">
+          <%= l(:label_time_zone) %>
+          <%= Time.zone.to_s %>
+        </label>
       </label>
       <%= f.text_field :start_time_hour,
             id: 'meeting-form-start-time',
@@ -61,7 +63,7 @@ See doc/COPYRIGHT.md for more details.
 
   <div class="form--field">
     <label for="meeting-form-duration" class="form--label -required">
-      <%= Meeting.human_attribute_name(:duration) %>
+      <span aria-hidden="true"><%= Meeting.human_attribute_name(:duration) %></span>
       <span class="hidden-for-sighted"><%= l(:text_in_hours)%>  <%=l(:text_hours_between, min: 1, max: 168) %></span>
     </label>
 


### PR DESCRIPTION
This changes the used labels (if possible) for a correct translation. In two cases the lang-attribute was set since there is no translation at the moment.

https://community.openproject.org/work_packages/20428/activity
