### PR TITLE
Add iCalendar support

### DIFF
--- a/app/controllers/meeting_contents_controller.rb
+++ b/app/controllers/meeting_contents_controller.rb
@@ -83,23 +83,14 @@ class MeetingContentsController < ApplicationController
 
   def notify
     unless @content.new_record?
-      author_mail = @content.meeting.author.mail
-      do_not_notify_author = @content.meeting.author.preference[:no_self_notified]
+      service = MeetingNotificationService.new(@meeting, @content_type)
+      result = service.call(@content, :content_for_review)
 
-      recipients_with_errors = []
-      @content.meeting.participants.each do |recipient|
-        begin
-          next if recipient.mail == author_mail && do_not_notify_author
-          MeetingMailer.content_for_review(@content, @content_type, recipient.mail).deliver_now
-        rescue
-          recipients_with_errors << recipient
-        end
-      end
-      if recipients_with_errors == []
+      if result.success?
         flash[:notice] = l(:notice_successful_notification)
       else
         flash[:error] = l(:error_notification_with_errors,
-                          recipients: recipients_with_errors.map(&:name).join('; '))
+                          recipients: result.errors.map(&:name).join('; '))
       end
     end
     redirect_back_or_default controller: '/meetings', action: 'show', id: @meeting
@@ -107,17 +98,10 @@ class MeetingContentsController < ApplicationController
   
   def icalendar
     unless @content.new_record?
-      author_mail = @content.meeting.author.mail
+      service = MeetingNotificationService.new(@meeting, @content_type)
+      result = service.call(@content, :icalendar_notification)
 
-      recipients_with_errors = []
-      @content.meeting.participants.each do |recipient|
-        begin
-          MeetingMailer.publish_icalendar(@content, @content_type, recipient.mail).deliver_now
-        rescue
-          recipients_with_errors << recipient
-        end
-      end
-      if recipients_with_errors == []
+      if result.success?
         flash[:notice] = l(:notice_successful_notification)
       else
         flash[:error] = l(:error_notification_with_errors,

--- a/app/helpers/meeting_contents_helper.rb
+++ b/app/helpers/meeting_contents_helper.rb
@@ -37,6 +37,7 @@ module MeetingContentsHelper
     menu << meeting_content_edit_link(content_type) if can_edit_meeting_content?(content, content_type)
     menu << meeting_content_history_link(content_type, content.meeting)
     menu << meeting_content_notify_link(content_type, content.meeting) if saved_meeting_content_text_present?(content)
+    menu << meeting_content_icalendar_link(content_type, content.meeting) if saved_meeting_content_text_present?(content)
     menu.join(' ')
   end
 
@@ -120,6 +121,16 @@ module MeetingContentsHelper
                               action: 'notify', meeting_id: meeting },
                             method: :put,
                             class: 'button icon-context icon-mail1'
+    end
+  end
+  
+  def meeting_content_icalendar_link(content_type, meeting)
+    content_tag :li, '', class: 'toolbar-item' do
+      link_to_if_authorized l(:label_icalendar),
+                            { controller: '/' + content_type.pluralize,
+                              action: 'icalendar', meeting_id: meeting },
+                            method: :put,
+                            class: 'button icon-context icon-mail'
     end
   end
 end

--- a/app/helpers/meeting_contents_helper.rb
+++ b/app/helpers/meeting_contents_helper.rb
@@ -36,8 +36,12 @@ module MeetingContentsHelper
     menu << meeting_agenda_toggle_status_link(content, content_type)
     menu << meeting_content_edit_link(content_type) if can_edit_meeting_content?(content, content_type)
     menu << meeting_content_history_link(content_type, content.meeting)
-    menu << meeting_content_notify_link(content_type, content.meeting) if saved_meeting_content_text_present?(content)
-    menu << meeting_content_icalendar_link(content_type, content.meeting) if saved_meeting_content_text_present?(content)
+
+    if saved_meeting_content_text_present?(content)
+      menu << meeting_content_notify_link(content_type, content.meeting)
+      menu << meeting_content_icalendar_link(content_type, content.meeting)
+    end
+
     menu.join(' ')
   end
 
@@ -130,7 +134,7 @@ module MeetingContentsHelper
                             { controller: '/' + content_type.pluralize,
                               action: 'icalendar', meeting_id: meeting },
                             method: :put,
-                            class: 'button icon-context icon-mail'
+                            class: 'button icon-context icon-calendar2'
     end
   end
 end

--- a/app/mailers/meeting_mailer.rb
+++ b/app/mailers/meeting_mailer.rb
@@ -42,6 +42,8 @@ class MeetingMailer < UserMailer
     headers['Content-Transfer-Encoding'] = '8bit'
     subject = "[#{@meeting.project.name}] #{I18n.t(:"label_#{content_type}")}: #{@meeting.title}"
     now = DateTime.now.strftime("%Y%m%dT%H%M%SZ")
+    author = Icalendar::Values::CalAddress.new("mailto:#{@meeting.author.mail}",
+                                               cn: @meeting.author.name)
 
     # Create a calendar with an event (standard method)
     entry = ::Icalendar::Calendar.new
@@ -52,6 +54,7 @@ class MeetingMailer < UserMailer
       e.summary     = "[#{@meeting.project.name}] #{@meeting.title}"
       e.description = subject
       e.uid         = "#{@meeting.id}@#{@meeting.project.identifier}"
+      e.organizer   = author
     end
 
     attachments['meeting.ics'] = entry.to_ical

--- a/app/mailers/meeting_mailer.rb
+++ b/app/mailers/meeting_mailer.rb
@@ -29,4 +29,43 @@ class MeetingMailer < UserMailer
     subject = "[#{@meeting.project.name}] #{I18n.t(:"label_#{content_type}")}: #{@meeting.title}"
     mail to: address, subject: subject
   end
+  
+  def publish_icalendar(content, content_type, address)
+    @meeting = content.meeting
+    @content_type = content_type
+    
+    open_project_headers 'Project' => @meeting.project.identifier,
+                         'Meeting-Id' => @meeting.id
+    headers['Content-Type'] = 'text/calendar; charset=utf-8; method="PUBLISH"; name="meeting.ics"'
+    headers['Content-Transfer-Encoding'] = '8bit'
+    subject = "[#{@meeting.project.name}] #{I18n.t(:"label_#{content_type}")}: #{@meeting.title}"
+    mystartdate = @meeting.start_time.strftime("%Y%m%dT%H%M%SZ")
+    myenddate = @meeting.end_time.strftime("%Y%m%dT%H%M%SZ")
+    url = meeting_url(@meeting)
+    now = DateTime.now.strftime("%Y%m%dT%H%M%SZ")
+
+    ical = "BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:OpenProject Meeting
+BEGIN:VEVENT
+SUMMARY:[#{@meeting.project.name}] #{@meeting.title}
+LOCATION:#{@meeting.location}
+DTSTAMP:#{now}
+DTSTART:#{mystartdate}
+DTEND:#{myenddate}
+DESCRIPTION:
+METHOD:PUBLISH
+ORGANIZER;CN=\"#{@meeting.author}\":MAILTO:#{@meeting.author.mail}
+UID:#{@meeting.id}@#{@meeting.project.identifier}
+SEQUENCE:0
+URL:#{url}
+END:VEVENT
+END:VCALENDAR"
+
+    mail(to: address, subject: subject) do |format|
+       format.ics {
+         render :text => ical, :layout => false
+      }
+    end
+  end
 end

--- a/app/services/meeting_notification_service.rb
+++ b/app/services/meeting_notification_service.rb
@@ -1,0 +1,36 @@
+class MeetingNotificationService
+
+  attr_reader :meeting, :content_type
+
+  def initialize(meeting, content_type)
+    @meeting = meeting
+    @content_type = content_type
+  end
+
+  def call(content, action)
+    recipients_with_errors = send_notifications!(content, action)
+    ServiceResult.new(success: recipients_with_errors.empty?, errors: recipients_with_errors)
+  end
+
+  private
+
+  def send_notifications!(content, action)
+    author_mail = meeting.author.mail
+    do_not_notify_author = meeting.author.pref[:no_self_notified]
+
+    recipients_with_errors = []
+    meeting.participants.each do |recipient|
+      begin
+        next if recipient.mail == author_mail && do_not_notify_author
+        MeetingMailer.send(action, content, content_type, recipient.mail).deliver_now
+      rescue => e
+        Rails.logger.error {
+          "Failed to deliver icalendar notification to #{recipient.login}: #{e.message}"
+        }
+        recipients_with_errors << recipient
+      end
+    end
+
+    recipients_with_errors
+  end
+end

--- a/app/views/meeting_mailer/icalendar_notification.html.erb
+++ b/app/views/meeting_mailer/icalendar_notification.html.erb
@@ -1,0 +1,11 @@
+<h1><%= link_to(@meeting.project.name, project_url(@meeting.project)) %>: <%= link_to(@meeting.title, meeting_url(@meeting)) %></h1>
+<em><%= @meeting.author %></em>
+
+<p><%= t(:text_notificiation_invited) %></p>
+
+<ul>
+<li><%=t :label_meeting_date_time %>: <%= format_date @meeting.start_date %> <%= format_time @meeting.start_time, false %>-<%= format_time @meeting.end_time, false %> <%= Time.zone %></li>
+<li><%=Meeting.human_attribute_name(:location) %>: <%= @meeting.location %></li>
+<li><%=Meeting.human_attribute_name(:participants_invited) %>: <%= @meeting.participants.invited.sort.join("; ") %></li>
+<li><%=Meeting.human_attribute_name(:participants_attended) %>: <%= @meeting.participants.attended.sort.join("; ") %></li>
+</ul>

--- a/app/views/meeting_mailer/icalendar_notification.text.erb
+++ b/app/views/meeting_mailer/icalendar_notification.text.erb
@@ -1,0 +1,9 @@
+<%= link_to(@meeting.project.name, project_url(@meeting.project)) %>: <%= link_to(@meeting.title, meeting_url(@meeting)) %>
+<%= @meeting.author %>
+
+<%= t(:text_notificiation_invited) %>
+
+<%=t :label_meeting_date_time %>: <%= format_date @meeting.start_date %> <%= format_time @meeting.start_time, false %>-<%= format_time @meeting.end_time, false %> <%= Time.zone %>
+<%=Meeting.human_attribute_name(:location) %>: <%= @meeting.location %>
+<%=Meeting.human_attribute_name(:participants_invited) %>: <%= @meeting.participants.invited.sort.join("; ") %>
+<%=Meeting.human_attribute_name(:participants_attended) %>: <%= @meeting.participants.attended.sort.join("; ") %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -84,3 +84,4 @@ en:
   text_meeting_minutes_for_meeting: 'minutes for the meeting "%{meeting}"'
   text_review_meeting_agenda: "%{author} has put the %{link} up for review."
   text_review_meeting_minutes: "%{author} has put the %{link} up for review."
+  text_notificiation_invited: "This mail contains an ics entry for the meeting below:"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -58,6 +58,7 @@ en:
   label_meeting_date_time: "Date/Time"
   label_meeting_diff: "Diff"
   label_notify: "Send for review"
+  label_icalendar: "Send iCalendar"
   label_version: "Version"
   label_time_zone: "Time zone"
   label_start_date: "Start date"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,6 +33,7 @@ OpenProject::Application.routes.draw do
         put :close
         put :open
         put :notify
+        put :icalendar
         post :preview
       end
 

--- a/lib/open_project/meeting/default_data.rb
+++ b/lib/open_project/meeting/default_data.rb
@@ -25,6 +25,7 @@ module OpenProject
           :create_meeting_agendas,
           :close_meeting_agendas,
           :send_meeting_agendas_notification,
+          :send_meeting_agendas_icalendar,
           :create_meeting_minutes,
           :send_meeting_minutes_notification
         ]

--- a/lib/open_project/meeting/engine.rb
+++ b/lib/open_project/meeting/engine.rb
@@ -38,6 +38,7 @@ module OpenProject::Meeting
         permission :create_meeting_agendas, { meeting_agendas: [:update, :preview] }, require: :member
         permission :close_meeting_agendas, { meeting_agendas: [:close, :open] }, require: :member
         permission :send_meeting_agendas_notification, { meeting_agendas: [:notify] }, require: :member
+        permission :send_meeting_agendas_icalendar, { meeting_agendas: [:icalendar] }, require: :member
         permission :create_meeting_minutes, { meeting_minutes: [:update, :preview] }, require: :member
         permission :send_meeting_minutes_notification, { meeting_minutes: [:notify] }, require: :member
       end

--- a/lib/open_project/meeting/engine.rb
+++ b/lib/open_project/meeting/engine.rb
@@ -34,6 +34,7 @@ module OpenProject::Meeting
         permission :create_meetings, { meetings: [:new, :create, :copy] }, require: :member
         permission :edit_meetings, { meetings: [:edit, :update] }, require: :member
         permission :delete_meetings, { meetings: [:destroy] }, require: :member
+        permission :meetings_send_invite, { meetings: [:icalendar] }, require: :member
         permission :view_meetings, meetings: [:index, :show], meeting_agendas: [:history, :show, :diff], meeting_minutes: [:history, :show, :diff]
         permission :create_meeting_agendas, { meeting_agendas: [:update, :preview] }, require: :member
         permission :close_meeting_agendas, { meeting_agendas: [:close, :open] }, require: :member

--- a/openproject-meeting.gemspec
+++ b/openproject-meeting.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir['spec/**/*']
 
   s.add_dependency 'rails', '~> 4.2.4'
+  s.add_dependency 'icalendar', '~> 2.3.0'
 
   s.add_development_dependency 'factory_girl_rails', '~> 4.0'
 end


### PR DESCRIPTION
This extends #107 with several features:
1. Use the icalendar gem for ics generation instead of manually writing it
2. Attach the ics alongside a proper mail body
3. Add a permission to the button

**Original PR (https://github.com/finnlabs/openproject-meeting/pull/107)**

Adds basic support for iCalendar notifications.
Closes #104 
### What it does:
- Adds a button to send iCalendar **notifications** (method PUBLISH) via email to all invited users
### What is not included:
- Locales other than English
- Tests
- Support for sending _updates_ / _cancel_ notifications
### What can / should be improved:
- Insert agenda items into description
- Use method=REQUEST instead of method=PUBLISH
- Any **substantial** modification (e.g. start/end time) should increment the sequence number of the calendar object
