### PR TITLE
[20449] [Accessibility] Some error messages cannot be perceived with the screen reader (Meetings)

### DIFF
--- a/app/views/meetings/_form.html.erb
+++ b/app/views/meetings/_form.html.erb
@@ -36,7 +36,8 @@ See doc/COPYRIGHT.md for more details.
       <span aria-hidden="true"><%= Meeting.human_attribute_name(:start_date) %>
         <span class="form--label-required" aria-hidden="true">*</span>
       </span>
-      <span class="hidden-for-sighted"><%= l(:label_start_date)%></span>
+      <span class="hidden-for-sighted"><%= l(:label_start_date)%>
+        <%=l(:text_hint_date_format) %></span>
     </label>
 
     <div class="form--field-container">


### PR DESCRIPTION
This adds a hint label for date picker. Thus blind users know which date to enter to avoid an automatic change which cannot be perceived. 
The core PR which adds the new label: https://github.com/opf/openproject/pull/4399

https://community.openproject.com/work_packages/20449/activity
