### PR TITLE
20428] [Accessibility] Some form fields are not pronounced with their entire label (3) (Meeting)

### DIFF
--- a/app/views/meetings/_form.html.erb
+++ b/app/views/meetings/_form.html.erb
@@ -36,7 +36,7 @@ See doc/COPYRIGHT.md for more details.
       <span aria-hidden="true"><%= Meeting.human_attribute_name(:start_date) %>
         <span class="form--label-required" aria-hidden="true">*</span>
       </span>
-      <span class="hidden-for-sighted"><%= l(:label_start_date)%>
+      <span class="hidden-for-sighted"><%= Meeting.human_attribute_name(:start_date) %>
         <%=l(:text_hint_date_format) %></span>
     </label>
 
@@ -69,7 +69,7 @@ See doc/COPYRIGHT.md for more details.
       <span aria-hidden="true"><%= Meeting.human_attribute_name(:duration) %>
         <span class="form--label-required" aria-hidden="true">*</span>
       </span>
-      <span class="hidden-for-sighted" lang="en"><%= l(:text_in_hours)%>  <%=l(:text_hours_between, min: 1, max: 168) %></span>
+      <span class="hidden-for-sighted"><%= Meeting.human_attribute_name(:duration) + ' ' + l(:text_in_hours) + ' ' + l(:text_hours_between, min: 1, max: 168) %></span>
     </label>
 
     <div class="form--field-container">


### PR DESCRIPTION
This improves labels for screen reader.

According core PR: opf/openproject#4487
According cost PR: https://github.com/finnlabs/openproject-costs/pull/241

WP: https://community.openproject.com/work_packages/20428/activity
