### PR TITLE
[23476] [6f]  Wenige Formularfelder werden ohne ihre Beschriftung ausgegeben

### DIFF
--- a/app/views/meetings/_form.html.erb
+++ b/app/views/meetings/_form.html.erb
@@ -66,10 +66,9 @@ See doc/COPYRIGHT.md for more details.
 
   <div class="form--field">
     <label for="meeting-form-duration" class="form--label -required">
-      <span aria-hidden="true"><%= Meeting.human_attribute_name(:duration) %>
+      <span><%= Meeting.human_attribute_name(:duration) %>
         <span class="form--label-required" aria-hidden="true">*</span>
       </span>
-      <span class="hidden-for-sighted"><%= t(:text_duration_in_hours) %></span>
     </label>
 
     <div class="form--field-container">


### PR DESCRIPTION
This removes redundant information for the screenreader.

https://community.openproject.com/work_packages/23476/activity
