### PR TITLE
[23450] [8a] Aktuelle Position nicht im Menü gekennzeichnet (Meetings)

### DIFF
--- a/app/controllers/meetings_controller.rb
+++ b/app/controllers/meetings_controller.rb
@@ -81,6 +81,10 @@ class MeetingsController < ApplicationController
   def new
   end
 
+  current_menu_item :new do
+    :meetings
+  end
+
   def copy
     params[:copied_from_meeting_id] = @meeting.id
     params[:copied_meeting_agenda_text] = @meeting.agenda.text if @meeting.agenda.present?


### PR DESCRIPTION
This highlights the entry 'meetings' in the menu when creating a new meeting.

Related: 
- https://github.com/opf/openproject/pull/4809
- https://github.com/finnlabs/openproject-costs/pull/252

https://community.openproject.com/work_packages/23450/activity
