### PR TITLE
[23980] Add buttons are not consistently used (Meetings)

### DIFF
--- a/app/views/meetings/index.html.erb
+++ b/app/views/meetings/index.html.erb
@@ -23,9 +23,13 @@ See doc/COPYRIGHT.md for more details.
 
 <%= toolbar title: l(:label_meeting_plural) do %>
   <% if authorize_for(:meetings, :new) %>
-      <a href="<%= new_meeting_path %>" id="add-meeting-button" title="Add meeting" class="button -alt-highlight">
+      <a href="<%= new_meeting_path %>"
+         id="add-meeting-button"
+         title="<%= I18n.t(:label_meeting_new) %>"
+         arial-label="<%= I18n.t(:label_meeting_new) %>"
+         class="button -alt-highlight">
         <i class="button--icon icon-add"></i>
-        <span class="button--text"><%= I18n.t(:label_meeting_new) %></span>
+        <span class="button--text"><%= t(:label_meeting) %></span>
       </a>
   <% end %>
 <% end %>


### PR DESCRIPTION
The makes the use of 'add' buttons consistent.

https://community.openproject.com/work_packages/23980/activity

Related PRs:
- https://github.com/finnlabs/openproject-backlogs/pull/230
- https://github.com/finnlabs/openproject-my_project_page/pull/83
- https://github.com/opf/openproject-documents/pull/64
- https://github.com/finnlabs/openproject-global_roles/pull/64
- https://github.com/finnlabs/openproject-pdf_export/pull/53
- https://github.com/opf/openproject/pull/4879
