### PR TITLE
[24165] Cancel button on meeting redirects to landing page

### DIFF
--- a/app/helpers/meeting_contents_helper.rb
+++ b/app/helpers/meeting_contents_helper.rb
@@ -95,10 +95,10 @@ module MeetingContentsHelper
       content_tag :button,
                   '',
                   class: 'button button--edit-agenda',
-                  onclick: "$$('.edit-#{content_type}').invoke('show');
-                            $$('.show-#{content_type}').invoke('hide');
-                            $$('.button--edit-agenda').invoke('addClassName', '-active');
-                            $$('.button--edit-agenda').invoke('disable');
+                  onclick: "jQuery('.edit-#{content_type}').show();
+                            jQuery('.show-#{content_type}').hide();
+                            jQuery('.button--edit-agenda').addClass('-active');
+                            jQuery('.button--edit-agenda').attr('disabled', true);
                   return false;" do
         link_to l(:button_edit),
                 '',
@@ -127,7 +127,7 @@ module MeetingContentsHelper
                             class: 'button icon-context icon-mail1'
     end
   end
-  
+
   def meeting_content_icalendar_link(content_type, meeting)
     content_tag :li, '', class: 'toolbar-item' do
       link_to_if_authorized l(:label_icalendar),

--- a/app/views/meeting_contents/_form.html.erb
+++ b/app/views/meeting_contents/_form.html.erb
@@ -30,10 +30,10 @@ See doc/COPYRIGHT.md for more details.
 <% path = send("preview_#{content_type}_path", content.meeting) %>
 <%= preview_link path, "#{content_type}_form", { class: 'button preview' } %>
 <%= link_to l(:button_cancel), "#",
-      :onclick => "$$('.show-#{content_type}').invoke('show');
-                   $$('.edit-#{content_type}').invoke('hide');
-                   $$('.button--edit-agenda').invoke('removeClassName', '-active');
-                   $$('.button--edit-agenda').invoke('enable');
+      :onclick => "jQuery('.show-#{content_type}').show();
+                   jQuery('.edit-#{content_type}').hide();
+                   jQuery('.button--edit-agenda').removeClass('-active');
+                   jQuery('.button--edit-agenda').removeAttr('disabled');;
                    return false;",
       class: 'button' %></p>
 <%= wikitoolbar_for "#{content_type}_text" %>

--- a/app/views/meeting_contents/_show.html.erb
+++ b/app/views/meeting_contents/_show.html.erb
@@ -44,7 +44,7 @@ See doc/COPYRIGHT.md for more details.
     <%= no_results_box %>
   <% end -%>
 
-  <%= javascript_tag(show_meeting_content_editor?(content, content_type) ? "$$('.show-#{content_type}').invoke('hide');" : "$$('.edit-#{content_type}').invoke('hide');") %>
+  <%= javascript_tag(show_meeting_content_editor?(content, content_type) ? "jQuery('.show-#{content_type}').hide();" : "jQuery('.edit-#{content_type}').hide();") %>
 </div>
 
 <%= render :partial => 'shared/meeting_header' %>


### PR DESCRIPTION
This replaces old prototype code with jQuery. Thus editing/canceling an agenda in a meeting is possible again.

https://community.openproject.com/work_packages/24165/activity
