### PR TITLE
[24372] Indentation too large when there is no avatar

### DIFF
--- a/app/assets/stylesheets/meeting/meeting.css.erb
+++ b/app/assets/stylesheets/meeting/meeting.css.erb
@@ -37,7 +37,7 @@ dl.meetings p {margin-bottom: 0.75em;}
   margin-bottom: 1rem;
 }
 
-.meeting.details .block--author .author {
+.meeting.details .block--author .avatar ~ .author {
   margin-left: 10px;
 }
 


### PR DESCRIPTION
This avoids a too large indentation when there is no avatar on the meetings overview page.

https://community.openproject.com/projects/openproject/work_packages/24372/activity