### PR TITLE
add timezone info (UTC) to icalendar events

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@
 language: ruby
 
 rvm:
-  - 2.4.1
+  - 2.4.2
 
 sudo: false
 


### PR DESCRIPTION
Fix https://community.openproject.com/projects/openproject/work_packages/26480 as proposed in 
https://github.com/icalendar/icalendar/tree/v2.4.0#timezones.

At least in my calendar application it works as desired.